### PR TITLE
활성화 상태 관리 및 공지사항 게시기간 기능 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/siteguard/attendance/client/AttendanceApiClient.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/attendance/client/AttendanceApiClient.kt
@@ -13,7 +13,7 @@ private val log = KotlinLogging.logger {}
 
 @Component
 class AttendanceApiClient(
-    private val webClientFactory: WebClientFactory,
+    webClientFactory: WebClientFactory,
     private val attendanceProperties: AttendanceProperties,
 ) {
     private val client: WebClient =

--- a/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
@@ -106,6 +106,8 @@ enum class ErrorCode(
     NOT_FOUND_KEY_MANAGEMENT(HttpStatus.NOT_FOUND, "ID가 %s인 주요관리사항을 찾을 수 없습니다."),
     DUPLICATE_KEY_MANAGEMENT_DISPLAY_ORDER(HttpStatus.BAD_REQUEST, "타입 %s에 이미 %s번 값이 존재합니다."),
     NOT_FOUND_NOTICE(HttpStatus.NOT_FOUND, "ID가 %s인 공지사항을 찾을 수 없습니다."),
+    INVALID_NOTICE_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "상시 게시가 아닌 경우 시작일 또는 종료일 중 하나는 필수입니다."),
+    INVALID_NOTICE_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일이 종료일보다 이후일 수 없습니다."),
     NOT_FOUND_ATTENDANCE(HttpStatus.NOT_FOUND, "ID가 %s인 출역현황을 찾을 수 없습니다."),
     NOT_FOUND_OBSERVATION(HttpStatus.NOT_FOUND, "ID가 %s인 드론 관측 데이터를 찾을 수 없습니다."),
 

--- a/src/main/kotlin/com/pluxity/siteguard/goal/dto/GoalRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/goal/dto/GoalRequest.kt
@@ -33,4 +33,6 @@ data class GoalRequest(
     val completionDate: LocalDate,
     @field:Schema(description = "지연일", example = "5")
     val delayDays: Int,
+    @field:Schema(description = "활성화 여부", example = "true")
+    val isActive: Boolean = false,
 )

--- a/src/main/kotlin/com/pluxity/siteguard/goal/dto/GoalResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/goal/dto/GoalResponse.kt
@@ -34,6 +34,8 @@ data class GoalResponse(
     val plannedWorkDays: Int,
     @field:Schema(description = "지연일", example = "5")
     val delayDays: Int,
+    @field:Schema(description = "활성화 여부", example = "true")
+    val isActive: Boolean,
 )
 
 fun Goal.toResponse(): GoalResponse =
@@ -52,4 +54,5 @@ fun Goal.toResponse(): GoalResponse =
         completionDate = this.completionDate,
         plannedWorkDays = this.plannedWorkDays,
         delayDays = this.delayDays,
+        isActive = this.isActive,
     )

--- a/src/main/kotlin/com/pluxity/siteguard/goal/entity/Goal.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/goal/entity/Goal.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.ColumnDefault
 import java.time.LocalDate
 
 @Entity
@@ -48,6 +49,9 @@ class Goal(
     var plannedWorkDays: Int,
     @Column(name = "delay_days")
     var delayDays: Int,
+    @Column(name = "is_active", nullable = false)
+    @ColumnDefault("false")
+    var isActive: Boolean = false,
 ) : IdentityIdEntity() {
     fun update(
         constructionSection: ConstructionSection,
@@ -62,6 +66,7 @@ class Goal(
         completionDate: LocalDate,
         plannedWorkDays: Int,
         delayDays: Int,
+        isActive: Boolean,
     ) {
         this.constructionSection = constructionSection
         this.progressRate = progressRate
@@ -75,5 +80,6 @@ class Goal(
         this.completionDate = completionDate
         this.plannedWorkDays = plannedWorkDays
         this.delayDays = delayDays
+        this.isActive = isActive
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/goal/service/GoalService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/goal/service/GoalService.kt
@@ -88,6 +88,7 @@ class GoalService(
                         completionDate = item.completionDate,
                         plannedWorkDays = item.plannedWorkDays,
                         delayDays = item.delayDays,
+                        isActive = item.isActive,
                     ),
                 )
                 return@forEach
@@ -107,6 +108,7 @@ class GoalService(
                     completionDate = item.completionDate,
                     plannedWorkDays = item.plannedWorkDays,
                     delayDays = item.delayDays,
+                    isActive = item.isActive,
                 )
         }
     }

--- a/src/main/kotlin/com/pluxity/siteguard/notice/controller/NoticeController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/controller/NoticeController.kt
@@ -58,6 +58,25 @@ class NoticeController(
     ): ResponseEntity<DataResponseBody<PageResponse<NoticeResponse>>> =
         ResponseEntity.ok(DataResponseBody(service.findAll(PageSearchRequest(page, size))))
 
+    @Operation(summary = "현재 노출 중인 공지사항 조회", description = "현재 노출 중인 공지사항 목록을 조회합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @GetMapping("/active")
+    fun findActive(): ResponseEntity<DataResponseBody<List<NoticeResponse>>> = ResponseEntity.ok(DataResponseBody(service.findActive()))
+
     @Operation(summary = "공지사항 상세 조회", description = "공지사항을 상세 조회합니다")
     @ApiResponses(
         value = [

--- a/src/main/kotlin/com/pluxity/siteguard/notice/dto/NoticeRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/dto/NoticeRequest.kt
@@ -3,6 +3,7 @@ package com.pluxity.siteguard.notice.dto
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 @Schema(description = "공지사항 등록/수정 요청")
 data class NoticeRequest(
@@ -14,4 +15,12 @@ data class NoticeRequest(
     @field:NotBlank(message = "내용은 필수입니다")
     @field:Size(max = 1000, message = "내용은 최대 1000자까지 입력 가능합니다")
     val content: String,
+    @field:Schema(description = "노출 여부", example = "false")
+    val isVisible: Boolean = false,
+    @field:Schema(description = "상시 게시 여부", example = "false")
+    val isAlways: Boolean = false,
+    @field:Schema(description = "게시 시작일", example = "2026-01-01")
+    val startDate: LocalDate? = null,
+    @field:Schema(description = "게시 종료일", example = "2026-12-31")
+    val endDate: LocalDate? = null,
 )

--- a/src/main/kotlin/com/pluxity/siteguard/notice/dto/NoticeResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/dto/NoticeResponse.kt
@@ -5,6 +5,7 @@ import com.pluxity.siteguard.global.response.BaseResponse
 import com.pluxity.siteguard.global.response.toBaseResponse
 import com.pluxity.siteguard.notice.entity.Notice
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 @Schema(description = "공지사항 응답")
 data class NoticeResponse(
@@ -14,6 +15,14 @@ data class NoticeResponse(
     val title: String,
     @field:Schema(description = "내용", example = "공지사항 내용입니다")
     val content: String?,
+    @field:Schema(description = "노출 여부", example = "false")
+    val isVisible: Boolean,
+    @field:Schema(description = "상시 게시 여부", example = "false")
+    val isAlways: Boolean,
+    @field:Schema(description = "게시 시작일", example = "2026-01-01")
+    val startDate: LocalDate?,
+    @field:Schema(description = "게시 종료일", example = "2026-12-31")
+    val endDate: LocalDate?,
     @field:JsonUnwrapped
     val baseResponse: BaseResponse,
 )
@@ -23,5 +32,9 @@ fun Notice.toResponse(): NoticeResponse =
         id = this.requiredId,
         title = this.title,
         content = this.content,
+        isVisible = this.isVisible,
+        isAlways = this.isAlways,
+        startDate = this.startDate,
+        endDate = this.endDate,
         baseResponse = this.toBaseResponse(),
     )

--- a/src/main/kotlin/com/pluxity/siteguard/notice/entity/Notice.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/entity/Notice.kt
@@ -4,6 +4,8 @@ import com.pluxity.siteguard.global.entity.IdentityIdEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import org.hibernate.annotations.ColumnDefault
+import java.time.LocalDate
 
 @Entity
 @Table(name = "notice")
@@ -12,12 +14,30 @@ class Notice(
     var title: String,
     @Column(name = "content", length = 1000)
     var content: String?,
+    @Column(name = "is_visible", nullable = false)
+    @ColumnDefault("false")
+    var isVisible: Boolean = false,
+    @Column(name = "is_always", nullable = false)
+    @ColumnDefault("false")
+    var isAlways: Boolean = false,
+    @Column(name = "start_date")
+    var startDate: LocalDate? = null,
+    @Column(name = "end_date")
+    var endDate: LocalDate? = null,
 ) : IdentityIdEntity() {
     fun update(
         title: String,
         content: String,
+        isVisible: Boolean,
+        isAlways: Boolean,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
     ) {
         this.title = title
         this.content = content
+        this.isVisible = isVisible
+        this.isAlways = isAlways
+        this.startDate = startDate
+        this.endDate = endDate
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/service/NoticeService.kt
@@ -44,24 +44,30 @@ class NoticeService(
                 select(entity(Notice::class))
                     .from(entity(Notice::class))
                     .where(
-                        path(Notice::isVisible)
-                            .equal(true)
-                            .and(
-                                path(Notice::isAlways)
-                                    .equal(true)
-                                    .or(
-                                        path(Notice::startDate)
-                                            .lessThanOrEqualTo(today)
-                                            .and(path(Notice::endDate).greaterThanOrEqualTo(today)),
+                        and(
+                            path(Notice::isVisible).equal(true),
+                            or(
+                                path(Notice::isAlways).equal(true),
+                                and(
+                                    or(
+                                        path(Notice::startDate).isNull(),
+                                        path(Notice::startDate).lessThanOrEqualTo(today),
                                     ),
+                                    or(
+                                        path(Notice::endDate).isNull(),
+                                        path(Notice::endDate).greaterThanOrEqualTo(today),
+                                    ),
+                                ),
                             ),
+                        ),
                     ).orderBy(path(Notice::id).desc())
             }.map { it.toResponse() }
     }
 
     @Transactional
-    fun create(request: NoticeRequest): Long =
-        repository
+    fun create(request: NoticeRequest): Long {
+        validateDateRange(request)
+        return repository
             .save(
                 Notice(
                     title = request.title,
@@ -72,23 +78,39 @@ class NoticeService(
                     endDate = request.endDate,
                 ),
             ).requiredId
+    }
 
     @Transactional
     fun update(
         id: Long,
         request: NoticeRequest,
-    ) = getById(id).update(
-        title = request.title,
-        content = request.content,
-        isVisible = request.isVisible,
-        isAlways = request.isAlways,
-        startDate = request.startDate,
-        endDate = request.endDate,
-    )
+    ) {
+        validateDateRange(request)
+        getById(id).update(
+            title = request.title,
+            content = request.content,
+            isVisible = request.isVisible,
+            isAlways = request.isAlways,
+            startDate = request.startDate,
+            endDate = request.endDate,
+        )
+    }
 
     @Transactional
     fun delete(id: Long) {
         repository.deleteById(getById(id).requiredId)
+    }
+
+    private fun validateDateRange(request: NoticeRequest) {
+        if (!request.isVisible || request.isAlways) return
+
+        if (request.startDate == null && request.endDate == null) {
+            throw CustomException(ErrorCode.INVALID_NOTICE_DATE_REQUIRED)
+        }
+
+        if (request.startDate != null && request.endDate != null && request.startDate.isAfter(request.endDate)) {
+            throw CustomException(ErrorCode.INVALID_NOTICE_DATE_RANGE)
+        }
     }
 
     private fun getById(id: Long): Notice =

--- a/src/main/kotlin/com/pluxity/siteguard/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/notice/service/NoticeService.kt
@@ -5,6 +5,7 @@ import com.pluxity.siteguard.global.dto.PageSearchRequest
 import com.pluxity.siteguard.global.exception.CustomException
 import com.pluxity.siteguard.global.response.PageResponse
 import com.pluxity.siteguard.global.response.toPageResponse
+import com.pluxity.siteguard.global.utils.findAllNotNull
 import com.pluxity.siteguard.global.utils.findPageNotNull
 import com.pluxity.siteguard.notice.dto.NoticeRequest
 import com.pluxity.siteguard.notice.dto.NoticeResponse
@@ -15,6 +16,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
@@ -35,14 +37,54 @@ class NoticeService(
 
     fun findById(id: Long): NoticeResponse = getById(id).toResponse()
 
+    fun findActive(): List<NoticeResponse> {
+        val today = LocalDate.now()
+        return repository
+            .findAllNotNull {
+                select(entity(Notice::class))
+                    .from(entity(Notice::class))
+                    .where(
+                        path(Notice::isVisible)
+                            .equal(true)
+                            .and(
+                                path(Notice::isAlways)
+                                    .equal(true)
+                                    .or(
+                                        path(Notice::startDate)
+                                            .lessThanOrEqualTo(today)
+                                            .and(path(Notice::endDate).greaterThanOrEqualTo(today)),
+                                    ),
+                            ),
+                    ).orderBy(path(Notice::id).desc())
+            }.map { it.toResponse() }
+    }
+
     @Transactional
-    fun create(request: NoticeRequest): Long = repository.save(Notice(title = request.title, content = request.content)).requiredId
+    fun create(request: NoticeRequest): Long =
+        repository
+            .save(
+                Notice(
+                    title = request.title,
+                    content = request.content,
+                    isVisible = request.isVisible,
+                    isAlways = request.isAlways,
+                    startDate = request.startDate,
+                    endDate = request.endDate,
+                ),
+            ).requiredId
 
     @Transactional
     fun update(
         id: Long,
         request: NoticeRequest,
-    ) = getById(id).update(request.title, request.content)
+    ) = getById(id).update(
+        title = request.title,
+        content = request.content,
+        isVisible = request.isVisible,
+        isAlways = request.isAlways,
+        startDate = request.startDate,
+        endDate = request.endDate,
+    )
 
     @Transactional
     fun delete(id: Long) {

--- a/src/main/kotlin/com/pluxity/siteguard/processstatus/controller/ProcessStatusController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/processstatus/controller/ProcessStatusController.kt
@@ -78,7 +78,10 @@ class ProcessStatusController(
     fun findLatest(): ResponseEntity<DataResponseBody<List<ProcessStatusResponse>>> =
         ResponseEntity.ok(DataResponseBody(service.findLatest()))
 
-    @Operation(summary = "공정현황 저장/수정/삭제", description = "공정현황을 저장, 수정, 삭제합니다. upserts의 id가 없으면 생성, 있으면 수정합니다. deletedIds에 포함된 id는 삭제됩니다")
+    @Operation(
+        summary = "공정현황 저장/수정/삭제",
+        description = "공정현황을 저장, 수정, 삭제합니다. upserts의 id가 없으면 생성, 있으면 수정합니다. deletedIds에 포함된 id는 삭제됩니다",
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "송출 성공"),

--- a/src/main/kotlin/com/pluxity/siteguard/processstatus/dto/ProcessStatusRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/processstatus/dto/ProcessStatusRequest.kt
@@ -15,4 +15,6 @@ data class ProcessStatusRequest(
     val plannedRate: Int,
     @field:Schema(description = "공정률", example = "75")
     val actualRate: Int,
+    @field:Schema(description = "활성화 여부", example = "true")
+    val isActive: Boolean = false,
 )

--- a/src/main/kotlin/com/pluxity/siteguard/processstatus/dto/ProcessStatusResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/processstatus/dto/ProcessStatusResponse.kt
@@ -16,6 +16,8 @@ data class ProcessStatusResponse(
     val plannedRate: Int,
     @field:Schema(description = "공정률", example = "75")
     val actualRate: Int,
+    @field:Schema(description = "활성화 여부", example = "true")
+    val isActive: Boolean,
 )
 
 fun ProcessStatus.toResponse(): ProcessStatusResponse =
@@ -25,4 +27,5 @@ fun ProcessStatus.toResponse(): ProcessStatusResponse =
         workType = this.workType.toResponse(),
         plannedRate = this.plannedRate,
         actualRate = this.actualRate,
+        isActive = this.isActive,
     )

--- a/src/main/kotlin/com/pluxity/siteguard/processstatus/entity/ProcessStatus.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/processstatus/entity/ProcessStatus.kt
@@ -8,12 +8,18 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.ColumnDefault
 import java.time.LocalDate
 
 @Entity
 @Table(
     name = "process_status",
-    uniqueConstraints = [UniqueConstraint(name = "uk_process_status_work_date_work_type", columnNames = ["work_date", "work_type_id"])],
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_process_status_work_date_work_type",
+            columnNames = ["work_date", "work_type_id"],
+        ),
+    ],
 )
 class ProcessStatus(
     @Column(name = "work_date", nullable = false)
@@ -25,16 +31,21 @@ class ProcessStatus(
     var plannedRate: Int,
     @Column(name = "actual_rate")
     var actualRate: Int,
+    @Column(name = "is_active", nullable = false)
+    @ColumnDefault("false")
+    var isActive: Boolean = false,
 ) : IdentityIdEntity() {
     fun update(
         workDate: LocalDate,
         workType: WorkType,
         plannedRate: Int,
         actualRate: Int,
+        isActive: Boolean,
     ) {
         this.workDate = workDate
         this.workType = workType
         this.plannedRate = plannedRate
         this.actualRate = actualRate
+        this.isActive = isActive
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/processstatus/service/ProcessStatusService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/processstatus/service/ProcessStatusService.kt
@@ -79,6 +79,7 @@ class ProcessStatusService(
                         workType = workType,
                         plannedRate = item.plannedRate,
                         actualRate = item.actualRate,
+                        isActive = item.isActive,
                     ),
                 )
                 return@forEach
@@ -90,6 +91,7 @@ class ProcessStatusService(
                     workType = workType,
                     plannedRate = item.plannedRate,
                     actualRate = item.actualRate,
+                    isActive = item.isActive,
                 )
         }
     }

--- a/src/test/kotlin/com/pluxity/siteguard/goal/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/goal/dto/DummyDTOs.kt
@@ -23,6 +23,7 @@ fun dummyGoalRequest(
     completionDate: LocalDate = LocalDate.of(2026, 12, 31),
     plannedWorkDays: Int = 365,
     delayDays: Int = 0,
+    isActive: Boolean = false,
 ) = GoalRequest(
     id = id,
     inputDate = inputDate,
@@ -38,6 +39,7 @@ fun dummyGoalRequest(
     completionDate = completionDate,
     plannedWorkDays = plannedWorkDays,
     delayDays = delayDays,
+    isActive = isActive,
 )
 
 fun dummyGoalBulkRequest(

--- a/src/test/kotlin/com/pluxity/siteguard/goal/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/goal/entity/DummyEntities.kt
@@ -25,6 +25,7 @@ fun dummyGoal(
     completionDate: LocalDate = LocalDate.of(2026, 12, 31),
     plannedWorkDays: Int = 365,
     delayDays: Int = 0,
+    isActive: Boolean = false,
 ) = Goal(
     inputDate = inputDate,
     constructionSection = constructionSection,
@@ -39,4 +40,5 @@ fun dummyGoal(
     completionDate = completionDate,
     plannedWorkDays = plannedWorkDays,
     delayDays = delayDays,
+    isActive = isActive,
 ).withId(id)

--- a/src/test/kotlin/com/pluxity/siteguard/goal/service/GoalServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/goal/service/GoalServiceTest.kt
@@ -238,6 +238,55 @@ class GoalServiceTest :
                 }
             }
 
+            When("isActive가 true인 데이터를 저장하면") {
+                val request =
+                    dummyGoalBulkRequest(
+                        upserts = listOf(dummyGoalRequest(constructionSectionId = 1L, isActive = true)),
+                    )
+
+                val savedEntity = dummyGoal(constructionSection = section1, isActive = true)
+
+                every { constructionSectionRepository.findAllById(listOf(1L)) } returns listOf(section1)
+                every { repository.findAllById(emptyList()) } returns emptyList()
+                every { repository.save(any()) } returns savedEntity
+
+                service.saveOrUpdateAll(request)
+
+                Then("isActive가 true로 저장된다") {
+                    verify(exactly = 1) { repository.save(match { it.isActive }) }
+                }
+            }
+
+            When("isActive를 false에서 true로 수정하면") {
+                val existingEntity =
+                    dummyGoal(
+                        id = 1L,
+                        constructionSection = section1,
+                        isActive = false,
+                    )
+
+                val request =
+                    dummyGoalBulkRequest(
+                        upserts =
+                            listOf(
+                                dummyGoalRequest(
+                                    id = 1L,
+                                    constructionSectionId = 1L,
+                                    isActive = true,
+                                ),
+                            ),
+                    )
+
+                every { constructionSectionRepository.findAllById(listOf(1L)) } returns listOf(section1)
+                every { repository.findAllById(listOf(1L)) } returns listOf(existingEntity)
+
+                service.saveOrUpdateAll(request)
+
+                Then("isActive가 true로 변경된다") {
+                    existingEntity.isActive shouldBe true
+                }
+            }
+
             When("저장, 수정, 삭제가 동시에 요청되면") {
                 val existingEntity =
                     dummyGoal(

--- a/src/test/kotlin/com/pluxity/siteguard/notice/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/notice/dto/DummyDTOs.kt
@@ -1,9 +1,19 @@
 package com.pluxity.siteguard.notice.dto
 
+import java.time.LocalDate
+
 fun dummyNoticeRequest(
     title: String = "테스트 공지사항",
     content: String = "테스트 공지사항 내용입니다",
+    isVisible: Boolean = false,
+    isAlways: Boolean = false,
+    startDate: LocalDate? = null,
+    endDate: LocalDate? = null,
 ) = NoticeRequest(
     title = title,
     content = content,
+    isVisible = isVisible,
+    isAlways = isAlways,
+    startDate = startDate,
+    endDate = endDate,
 )

--- a/src/test/kotlin/com/pluxity/siteguard/notice/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/notice/entity/DummyEntities.kt
@@ -2,12 +2,21 @@ package com.pluxity.siteguard.notice.entity
 
 import com.pluxity.siteguard.base.entity.withAudit
 import com.pluxity.siteguard.base.entity.withId
+import java.time.LocalDate
 
 fun dummyNotice(
     id: Long? = null,
     title: String = "테스트 공지사항",
     content: String? = "테스트 공지사항 내용입니다",
+    isVisible: Boolean = false,
+    isAlways: Boolean = false,
+    startDate: LocalDate? = null,
+    endDate: LocalDate? = null,
 ) = Notice(
     title = title,
     content = content,
+    isVisible = isVisible,
+    isAlways = isAlways,
+    startDate = startDate,
+    endDate = endDate,
 ).withId(id).withAudit()

--- a/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
@@ -3,6 +3,7 @@ package com.pluxity.siteguard.notice.service
 import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
 import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
 import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.pluxity.siteguard.global.constant.ErrorCode
 import com.pluxity.siteguard.global.dto.PageSearchRequest
 import com.pluxity.siteguard.global.exception.CustomException
 import com.pluxity.siteguard.notice.dto.dummyNoticeRequest
@@ -221,6 +222,153 @@ class NoticeServiceTest :
                     result[0].isAlways shouldBe true
                     result[1].title shouldBe "기간 공지"
                     result[1].isVisible shouldBe true
+                }
+            }
+        }
+
+        Given("공지사항 게시기간 유효성 검증") {
+
+            When("노출+기간 게시인데 시작일/종료일 둘 다 없으면") {
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = null,
+                        endDate = null,
+                    )
+
+                Then("INVALID_NOTICE_DATE_REQUIRED 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.create(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_NOTICE_DATE_REQUIRED
+                }
+            }
+
+            When("노출+기간 게시인데 시작일이 종료일보다 이후이면") {
+                val today = LocalDate.now()
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = today.plusDays(10),
+                        endDate = today,
+                    )
+
+                Then("INVALID_NOTICE_DATE_RANGE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.create(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_NOTICE_DATE_RANGE
+                }
+            }
+
+            When("노출+기간 게시인데 시작일만 있으면") {
+                val today = LocalDate.now()
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = today,
+                        endDate = null,
+                    )
+                val savedEntity =
+                    dummyNotice(id = 10L, title = "테스트 공지사항", isVisible = true, isAlways = false, startDate = today)
+
+                every { repository.save(any()) } returns savedEntity
+
+                val result = service.create(request)
+
+                Then("정상적으로 저장된다") {
+                    result shouldBe 10L
+                }
+            }
+
+            When("노출+기간 게시인데 종료일만 있으면") {
+                val today = LocalDate.now()
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = null,
+                        endDate = today.plusDays(30),
+                    )
+                val savedEntity =
+                    dummyNotice(
+                        id = 11L,
+                        title = "테스트 공지사항",
+                        isVisible = true,
+                        isAlways = false,
+                        endDate = today.plusDays(30),
+                    )
+
+                every { repository.save(any()) } returns savedEntity
+
+                val result = service.create(request)
+
+                Then("정상적으로 저장된다") {
+                    result shouldBe 11L
+                }
+            }
+
+            When("노출+상시 게시이면 날짜 없어도") {
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = true,
+                        startDate = null,
+                        endDate = null,
+                    )
+                val savedEntity = dummyNotice(id = 12L, title = "테스트 공지사항", isVisible = true, isAlways = true)
+
+                every { repository.save(any()) } returns savedEntity
+
+                val result = service.create(request)
+
+                Then("정상적으로 저장된다") {
+                    result shouldBe 12L
+                }
+            }
+
+            When("미노출이면 날짜 없어도") {
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = false,
+                        isAlways = false,
+                        startDate = null,
+                        endDate = null,
+                    )
+                val savedEntity = dummyNotice(id = 13L, title = "테스트 공지사항")
+
+                every { repository.save(any()) } returns savedEntity
+
+                val result = service.create(request)
+
+                Then("정상적으로 저장된다") {
+                    result shouldBe 13L
+                }
+            }
+
+            When("수정 시 노출+기간 게시인데 시작일/종료일 둘 다 없으면") {
+                val existingEntity = dummyNotice(id = 1L, title = "기존 제목")
+                val request =
+                    dummyNoticeRequest(
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = null,
+                        endDate = null,
+                    )
+
+                every { repository.findByIdOrNull(1L) } returns existingEntity
+
+                Then("INVALID_NOTICE_DATE_REQUIRED 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.update(1L, request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_NOTICE_DATE_REQUIRED
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
@@ -99,6 +99,42 @@ class NoticeServiceTest :
                     verify(exactly = 1) { repository.save(any()) }
                 }
             }
+
+            When("노출 상태와 게시기간을 포함하여 등록하면") {
+                val today = LocalDate.now()
+                val request =
+                    dummyNoticeRequest(
+                        title = "노출 공지",
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = today,
+                        endDate = today.plusDays(30),
+                    )
+                val savedEntity =
+                    dummyNotice(
+                        id = 2L,
+                        title = "노출 공지",
+                        isVisible = true,
+                        isAlways = false,
+                        startDate = today,
+                        endDate = today.plusDays(30),
+                    )
+
+                every { repository.save(any()) } returns savedEntity
+
+                val result = service.create(request)
+
+                Then("노출 상태와 게시기간이 포함되어 저장된다") {
+                    result shouldBe 2L
+                    verify(exactly = 1) {
+                        repository.save(
+                            match {
+                                it.isVisible && !it.isAlways && it.startDate == today && it.endDate == today.plusDays(30)
+                            },
+                        )
+                    }
+                }
+            }
         }
 
         Given("공지사항 수정") {
@@ -113,6 +149,30 @@ class NoticeServiceTest :
 
                 Then("공지사항이 수정된다") {
                     existingEntity.title shouldBe "수정된 제목"
+                }
+            }
+
+            When("노출 상태와 게시기간을 수정하면") {
+                val today = LocalDate.now()
+                val existingEntity = dummyNotice(id = 1L, title = "기존 제목", isVisible = false)
+                val request =
+                    dummyNoticeRequest(
+                        title = "기존 제목",
+                        isVisible = true,
+                        isAlways = true,
+                        startDate = today,
+                        endDate = today.plusDays(7),
+                    )
+
+                every { repository.findByIdOrNull(1L) } returns existingEntity
+
+                service.update(1L, request)
+
+                Then("노출 상태와 게시기간이 수정된다") {
+                    existingEntity.isVisible shouldBe true
+                    existingEntity.isAlways shouldBe true
+                    existingEntity.startDate shouldBe today
+                    existingEntity.endDate shouldBe today.plusDays(7)
                 }
             }
 
@@ -147,7 +207,7 @@ class NoticeServiceTest :
                     )
 
                 every {
-                    repository.findAll<Notice>(
+                    repository.findAll(
                         init = any<Jpql.() -> JpqlQueryable<SelectQuery<Notice>>>(),
                     )
                 } returns entities

--- a/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/notice/service/NoticeServiceTest.kt
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
 
 class NoticeServiceTest :
     BehaviorSpec({
@@ -124,6 +125,42 @@ class NoticeServiceTest :
                     shouldThrow<CustomException> {
                         service.update(999L, request)
                     }
+                }
+            }
+        }
+
+        Given("현재 노출 중인 공지사항 조회") {
+
+            When("노출 중인 공지사항을 조회하면") {
+                val today = LocalDate.now()
+                val entities =
+                    listOf(
+                        dummyNotice(id = 1L, title = "상시 공지", isVisible = true, isAlways = true),
+                        dummyNotice(
+                            id = 2L,
+                            title = "기간 공지",
+                            isVisible = true,
+                            isAlways = false,
+                            startDate = today.minusDays(1),
+                            endDate = today.plusDays(1),
+                        ),
+                    )
+
+                every {
+                    repository.findAll<Notice>(
+                        init = any<Jpql.() -> JpqlQueryable<SelectQuery<Notice>>>(),
+                    )
+                } returns entities
+
+                val result = service.findActive()
+
+                Then("노출 중인 공지사항 목록이 반환된다") {
+                    result.size shouldBe 2
+                    result[0].title shouldBe "상시 공지"
+                    result[0].isVisible shouldBe true
+                    result[0].isAlways shouldBe true
+                    result[1].title shouldBe "기간 공지"
+                    result[1].isVisible shouldBe true
                 }
             }
         }

--- a/src/test/kotlin/com/pluxity/siteguard/processstatus/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/processstatus/dto/DummyDTOs.kt
@@ -14,12 +14,14 @@ fun dummyProcessStatusRequest(
     workTypeId: Long = 1L,
     plannedRate: Int = 100,
     actualRate: Int = 100,
+    isActive: Boolean = false,
 ) = ProcessStatusRequest(
     id = id,
     workDate = workDate,
     workTypeId = workTypeId,
     plannedRate = plannedRate,
     actualRate = actualRate,
+    isActive = isActive,
 )
 
 fun dummyProcessStatusBulkRequest(

--- a/src/test/kotlin/com/pluxity/siteguard/processstatus/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/processstatus/entity/DummyEntities.kt
@@ -16,9 +16,11 @@ fun dummyProcessStatus(
     workType: WorkType = dummyWorkType(id = 1L),
     plannedRate: Int = 100,
     actualRate: Int = 100,
+    isActive: Boolean = false,
 ) = ProcessStatus(
     workDate = workDate,
     workType = workType,
     plannedRate = plannedRate,
     actualRate = actualRate,
+    isActive = isActive,
 ).withId(id)

--- a/src/test/kotlin/com/pluxity/siteguard/processstatus/service/ProcessStatusServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/processstatus/service/ProcessStatusServiceTest.kt
@@ -229,6 +229,55 @@ class ProcessStatusServiceTest :
                 }
             }
 
+            When("isActive가 true인 데이터를 저장하면") {
+                val request =
+                    dummyProcessStatusBulkRequest(
+                        upserts = listOf(dummyProcessStatusRequest(workTypeId = 1L, isActive = true)),
+                    )
+
+                val savedEntity = dummyProcessStatus(isActive = true)
+
+                every { workTypeRepository.findAllById(listOf(1L)) } returns listOf(earthwork)
+                every { repository.findAllById(emptyList()) } returns emptyList()
+                every { repository.save(any()) } returns savedEntity
+
+                service.saveOrUpdateAll(request)
+
+                Then("isActive가 true로 저장된다") {
+                    verify(exactly = 1) { repository.save(match { it.isActive }) }
+                }
+            }
+
+            When("isActive를 false에서 true로 수정하면") {
+                val existingEntity =
+                    dummyProcessStatus(
+                        id = 1L,
+                        workType = earthwork,
+                        isActive = false,
+                    )
+
+                val request =
+                    dummyProcessStatusBulkRequest(
+                        upserts =
+                            listOf(
+                                dummyProcessStatusRequest(
+                                    id = 1L,
+                                    workTypeId = 1L,
+                                    isActive = true,
+                                ),
+                            ),
+                    )
+
+                every { workTypeRepository.findAllById(listOf(1L)) } returns listOf(earthwork)
+                every { repository.findAllById(listOf(1L)) } returns listOf(existingEntity)
+
+                service.saveOrUpdateAll(request)
+
+                Then("isActive가 true로 변경된다") {
+                    existingEntity.isActive shouldBe true
+                }
+            }
+
             When("저장, 수정, 삭제가 동시에 요청되면") {
                 val existingEntity =
                     dummyProcessStatus(

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/dto/DummyDTOs.kt
@@ -1,0 +1,6 @@
+package com.pluxity.siteguard.systemsetting.dto
+
+fun dummySystemSettingRequest(rollingIntervalSeconds: Int = 10) =
+    SystemSettingRequest(
+        rollingIntervalSeconds = rollingIntervalSeconds,
+    )

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/entity/DummyEntities.kt
@@ -1,0 +1,8 @@
+package com.pluxity.siteguard.systemsetting.entity
+
+import com.pluxity.siteguard.base.entity.withAudit
+
+fun dummySystemSetting(rollingIntervalSeconds: Int = 10) =
+    SystemSetting(
+        rollingIntervalSeconds = rollingIntervalSeconds,
+    ).withAudit()

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingServiceTest.kt
@@ -1,0 +1,75 @@
+package com.pluxity.siteguard.systemsetting.service
+
+import com.pluxity.siteguard.systemsetting.dto.dummySystemSettingRequest
+import com.pluxity.siteguard.systemsetting.entity.SystemSetting
+import com.pluxity.siteguard.systemsetting.entity.dummySystemSetting
+import com.pluxity.siteguard.systemsetting.repository.SystemSettingRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+
+class SystemSettingServiceTest :
+    BehaviorSpec({
+
+        val repository: SystemSettingRepository = mockk(relaxed = true)
+        val service = SystemSettingService(repository)
+
+        Given("시스템 설정 조회") {
+
+            When("저장된 설정이 있으면") {
+                val entity = dummySystemSetting(rollingIntervalSeconds = 15)
+
+                every { repository.findByIdOrNull(SystemSetting.SINGLETON_ID) } returns entity
+
+                val result = service.find()
+
+                Then("설정값이 반환된다") {
+                    result.rollingIntervalSeconds shouldBe 15
+                }
+            }
+
+            When("저장된 설정이 없으면") {
+                every { repository.findByIdOrNull(SystemSetting.SINGLETON_ID) } returns null
+
+                val result = service.find()
+
+                Then("기본 응답이 반환된다") {
+                    result.rollingIntervalSeconds shouldBe null
+                }
+            }
+        }
+
+        Given("시스템 설정 수정") {
+
+            When("기존 설정이 있으면") {
+                val existingEntity = dummySystemSetting(rollingIntervalSeconds = 10)
+                val request = dummySystemSettingRequest(rollingIntervalSeconds = 30)
+
+                every { repository.findByIdOrNull(SystemSetting.SINGLETON_ID) } returns existingEntity
+
+                service.update(request)
+
+                Then("기존 설정이 수정된다") {
+                    existingEntity.rollingIntervalSeconds shouldBe 30
+                    verify(exactly = 0) { repository.save(any()) }
+                }
+            }
+
+            When("기존 설정이 없으면") {
+                val request = dummySystemSettingRequest(rollingIntervalSeconds = 20)
+                val savedEntity = dummySystemSetting(rollingIntervalSeconds = 20)
+
+                every { repository.findByIdOrNull(SystemSetting.SINGLETON_ID) } returns null
+                every { repository.save(any()) } returns savedEntity
+
+                service.update(request)
+
+                Then("새로운 설정이 저장된다") {
+                    verify(exactly = 1) { repository.save(any()) }
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 요약
- 공정현황/목표관리 엔티티에 `isActive` 활성화 여부 필드 추가           
- 공지사항에 노출 상태(`isVisible`), 상시 여부(`isAlways`), 게시기간(`startDate`/`endDate`) 필드 추가
- 현재 노출 중인 공지사항 조회 API (`GET /notices/active`) 추가                                                                                              
- 시스템설정, 활성화여부, 공지사항 신규 필드에 대한 단위테스트 추가
## 이슈 넘버 or 관련 링크

## 변경사항 🏗️

<!-- 변경 사항에 대해서 기재 필요 -->

### Checklist 📋

## 코드 변경 사항

- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
