### PR TITLE
feat: 미디어서버 CCTV 동기화 및 즐겨찾기 관리 API 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/siteguard/attendance/client/AttendanceApiClient.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/attendance/client/AttendanceApiClient.kt
@@ -16,11 +16,7 @@ class AttendanceApiClient(
     webClientFactory: WebClientFactory,
     private val attendanceProperties: AttendanceProperties,
 ) {
-    private val client: WebClient =
-        webClientFactory
-            .createClient(attendanceProperties.url)
-            .mutate()
-            .build()
+    private val client: WebClient = webClientFactory.createClient(attendanceProperties.url)
 
     fun fetchAttendanceData(): List<AttendanceExternalData> {
         if (attendanceProperties.url.isBlank()) {

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/client/CctvApiClient.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/client/CctvApiClient.kt
@@ -1,0 +1,40 @@
+package com.pluxity.siteguard.cctv.client
+
+import com.pluxity.siteguard.cctv.dto.MediaServerPathItem
+import com.pluxity.siteguard.cctv.dto.MediaServerPathListResponse
+import com.pluxity.siteguard.global.config.WebClientFactory
+import com.pluxity.siteguard.global.properties.MediaServerProperties
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class CctvApiClient(
+    webClientFactory: WebClientFactory,
+    private val mediaServerProperties: MediaServerProperties,
+) {
+    private val client: WebClient =
+        webClientFactory
+            .createClient(mediaServerProperties.url)
+            .mutate()
+            .build()
+
+    fun fetchPaths(): List<MediaServerPathItem> {
+        if (mediaServerProperties.url.isBlank()) {
+            log.warn { "Media Server API URL is not configured" }
+            return emptyList()
+        }
+
+        val response =
+            client
+                .get()
+                .uri("/v3/paths/list")
+                .retrieve()
+                .bodyToMono<MediaServerPathListResponse>()
+                .block()
+        return response?.items ?: emptyList()
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/client/CctvApiClient.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/client/CctvApiClient.kt
@@ -3,29 +3,23 @@ package com.pluxity.siteguard.cctv.client
 import com.pluxity.siteguard.cctv.dto.MediaServerPathItem
 import com.pluxity.siteguard.cctv.dto.MediaServerPathListResponse
 import com.pluxity.siteguard.global.config.WebClientFactory
+import com.pluxity.siteguard.global.constant.ErrorCode
+import com.pluxity.siteguard.global.exception.CustomException
 import com.pluxity.siteguard.global.properties.MediaServerProperties
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
-
-private val log = KotlinLogging.logger {}
 
 @Component
 class CctvApiClient(
     webClientFactory: WebClientFactory,
     private val mediaServerProperties: MediaServerProperties,
 ) {
-    private val client: WebClient =
-        webClientFactory
-            .createClient(mediaServerProperties.url)
-            .mutate()
-            .build()
+    private val client: WebClient = webClientFactory.createClient(mediaServerProperties.url)
 
     fun fetchPaths(): List<MediaServerPathItem> {
         if (mediaServerProperties.url.isBlank()) {
-            log.warn { "Media Server API URL is not configured" }
-            return emptyList()
+            throw CustomException(ErrorCode.MEDIA_SERVER_URL_NOT_CONFIGURED)
         }
 
         val response =

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
@@ -1,0 +1,164 @@
+package com.pluxity.siteguard.cctv.controller
+
+import com.pluxity.siteguard.cctv.dto.CctvResponse
+import com.pluxity.siteguard.cctv.dto.CctvUpdateRequest
+import com.pluxity.siteguard.cctv.service.CctvService
+import com.pluxity.siteguard.global.response.DataResponseBody
+import com.pluxity.siteguard.global.response.ErrorResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/cctvs")
+@Tag(name = "CCTV Controller", description = "CCTV 관리 API")
+class CctvController(
+    private val service: CctvService,
+) {
+    @Operation(summary = "CCTV 동기화", description = "미디어서버에서 CCTV 경로 목록을 가져와 DB에 동기화합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "동기화 성공"),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @PostMapping("/sync")
+    fun sync(): ResponseEntity<Void> {
+        service.sync()
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "CCTV 목록 조회", description = "CCTV 목록을 조회합니다 (즐겨찾기 우선, 이름순 정렬)")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @GetMapping
+    fun findAll(): ResponseEntity<DataResponseBody<List<CctvResponse>>> = ResponseEntity.ok(DataResponseBody(service.findAll()))
+
+    @Operation(summary = "CCTV 수정", description = "CCTV의 이름, 경도, 위도를 수정합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "수정 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "CCTV를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @PatchMapping("/{id}")
+    fun update(
+        @PathVariable id: Long,
+        @RequestBody @Valid request: CctvUpdateRequest,
+    ): ResponseEntity<Void> {
+        service.update(id, request)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "CCTV 즐겨찾기 추가", description = "CCTV를 즐겨찾기에 추가합니다 (최대 4개)")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "즐겨찾기 추가 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "즐겨찾기 최대 개수 초과 또는 이미 즐겨찾기된 CCTV",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "CCTV를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @PostMapping("/{id}/favorite")
+    fun addFavorite(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.addFavorite(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "CCTV 즐겨찾기 해제", description = "CCTV의 즐겨찾기를 해제합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "즐겨찾기 해제 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "즐겨찾기가 아닌 CCTV",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "CCTV를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @DeleteMapping("/{id}/favorite")
+    fun removeFavorite(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.removeFavorite(id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvExternalResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvExternalResponse.kt
@@ -1,0 +1,13 @@
+package com.pluxity.siteguard.cctv.dto
+
+data class MediaServerPathListResponse(
+    val itemCount: Int,
+    val pageCount: Int,
+    val items: List<MediaServerPathItem>,
+)
+
+data class MediaServerPathItem(
+    val name: String,
+    val confName: String,
+    val ready: Boolean,
+)

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvResponse.kt
@@ -1,0 +1,36 @@
+package com.pluxity.siteguard.cctv.dto
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.pluxity.siteguard.cctv.entity.Cctv
+import com.pluxity.siteguard.global.response.BaseResponse
+import com.pluxity.siteguard.global.response.toBaseResponse
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "CCTV 응답")
+data class CctvResponse(
+    @field:Schema(description = "ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "경로", example = "cam1")
+    val path: String,
+    @field:Schema(description = "이름", example = "1번 카메라")
+    val name: String?,
+    @field:Schema(description = "경도", example = "127.0")
+    val lon: Double?,
+    @field:Schema(description = "위도", example = "37.0")
+    val lat: Double?,
+    @field:Schema(description = "즐겨찾기 여부", example = "false")
+    val isFavorite: Boolean,
+    @field:JsonUnwrapped
+    val baseResponse: BaseResponse,
+)
+
+fun Cctv.toResponse(): CctvResponse =
+    CctvResponse(
+        id = this.requiredId,
+        path = this.path,
+        name = this.name,
+        lon = this.lon,
+        lat = this.lat,
+        isFavorite = this.isFavorite,
+        baseResponse = this.toBaseResponse(),
+    )

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvUpdateRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvUpdateRequest.kt
@@ -1,0 +1,13 @@
+package com.pluxity.siteguard.cctv.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "CCTV 수정 요청")
+data class CctvUpdateRequest(
+    @field:Schema(description = "이름", example = "1번 카메라")
+    val name: String?,
+    @field:Schema(description = "경도", example = "127.0")
+    val lon: Double?,
+    @field:Schema(description = "위도", example = "37.0")
+    val lat: Double?,
+)

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/entity/Cctv.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/entity/Cctv.kt
@@ -1,0 +1,41 @@
+package com.pluxity.siteguard.cctv.entity
+
+import com.pluxity.siteguard.global.entity.IdentityIdEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.ColumnDefault
+
+@Entity
+@Table(name = "cctv_stream")
+class Cctv(
+    @Column(name = "path", nullable = false, unique = true)
+    val path: String,
+    @Column(name = "name")
+    var name: String? = null,
+    @Column(name = "lon")
+    var lon: Double? = null,
+    @Column(name = "lat")
+    var lat: Double? = null,
+    @Column(name = "is_favorite", nullable = false)
+    @ColumnDefault("false")
+    var isFavorite: Boolean = false,
+) : IdentityIdEntity() {
+    fun update(
+        name: String?,
+        lon: Double?,
+        lat: Double?,
+    ) {
+        this.name = name
+        this.lon = lon
+        this.lat = lat
+    }
+
+    fun markFavorite() {
+        this.isFavorite = true
+    }
+
+    fun unmarkFavorite() {
+        this.isFavorite = false
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvRepository.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvRepository.kt
@@ -1,0 +1,10 @@
+package com.pluxity.siteguard.cctv.repository
+
+import com.pluxity.siteguard.cctv.entity.Cctv
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CctvRepository : JpaRepository<Cctv, Long> {
+    fun countByIsFavoriteTrue(): Long
+
+    fun findAllByOrderByIsFavoriteDescNameAsc(): List<Cctv>
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
@@ -1,0 +1,91 @@
+package com.pluxity.siteguard.cctv.service
+
+import com.pluxity.siteguard.cctv.client.CctvApiClient
+import com.pluxity.siteguard.cctv.dto.CctvResponse
+import com.pluxity.siteguard.cctv.dto.CctvUpdateRequest
+import com.pluxity.siteguard.cctv.dto.toResponse
+import com.pluxity.siteguard.cctv.entity.Cctv
+import com.pluxity.siteguard.cctv.repository.CctvRepository
+import com.pluxity.siteguard.global.constant.ErrorCode
+import com.pluxity.siteguard.global.exception.CustomException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CctvService(
+    private val repository: CctvRepository,
+    private val apiClient: CctvApiClient,
+) {
+    companion object {
+        private const val MAX_FAVORITE_COUNT = 4
+    }
+
+    @Transactional
+    fun sync() {
+        val externalPaths = apiClient.fetchPaths()
+        val externalPathNames = externalPaths.map { it.name }
+
+        val existingCctvs = repository.findAll()
+        val existingPathMap = existingCctvs.associateBy { it.path }
+
+        // 새로운 path → Cctv 엔티티 생성 후 저장
+        val newCctvs =
+            externalPathNames
+                .filter { it !in existingPathMap }
+                .map { Cctv(path = it) }
+        if (newCctvs.isNotEmpty()) {
+            repository.saveAll(newCctvs)
+        }
+
+        // DB에 있지만 미디어서버에 없는 path → 삭제
+        val externalPathSet = externalPathNames.toSet()
+        val toDelete = existingCctvs.filter { it.path !in externalPathSet }
+        if (toDelete.isNotEmpty()) {
+            repository.deleteAll(toDelete)
+        }
+    }
+
+    fun findAll(): List<CctvResponse> =
+        repository
+            .findAllByOrderByIsFavoriteDescNameAsc()
+            .map { it.toResponse() }
+
+    @Transactional
+    fun update(
+        id: Long,
+        request: CctvUpdateRequest,
+    ) {
+        getById(id).update(
+            name = request.name,
+            lon = request.lon,
+            lat = request.lat,
+        )
+    }
+
+    @Transactional
+    fun addFavorite(id: Long) {
+        val cctv = getById(id)
+        if (cctv.isFavorite) {
+            throw CustomException(ErrorCode.ALREADY_FAVORITE, id)
+        }
+        if (repository.countByIsFavoriteTrue() >= MAX_FAVORITE_COUNT) {
+            throw CustomException(ErrorCode.EXCEED_FAVORITE_LIMIT)
+        }
+        cctv.markFavorite()
+    }
+
+    @Transactional
+    fun removeFavorite(id: Long) {
+        val cctv = getById(id)
+        if (!cctv.isFavorite) {
+            throw CustomException(ErrorCode.NOT_FAVORITE, id)
+        }
+        cctv.unmarkFavorite()
+    }
+
+    private fun getById(id: Long): Cctv =
+        repository.findByIdOrNull(id)
+            ?: throw CustomException(ErrorCode.NOT_FOUND_CCTV, id)
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
@@ -43,7 +43,7 @@ class CctvService(
         val externalPathSet = externalPathNames.toSet()
         val toDelete = existingCctvs.filter { it.path !in externalPathSet }
         if (toDelete.isNotEmpty()) {
-            repository.deleteAll(toDelete)
+            repository.deleteAllInBatch(toDelete)
         }
     }
 

--- a/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
@@ -111,6 +111,10 @@ enum class ErrorCode(
     NOT_FOUND_ATTENDANCE(HttpStatus.NOT_FOUND, "ID가 %s인 출역현황을 찾을 수 없습니다."),
     NOT_FOUND_OBSERVATION(HttpStatus.NOT_FOUND, "ID가 %s인 드론 관측 데이터를 찾을 수 없습니다."),
 
+    EXCEED_FAVORITE_LIMIT(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 4개까지 추가할 수 있습니다."),
+    ALREADY_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 이미 즐겨찾기되어 있습니다."),
+    NOT_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 즐겨찾기가 아닙니다."),
+
     INVALID_RESOURCE_IDS_INCLUDED(HttpStatus.BAD_REQUEST, "요청한 리소스 ID %s 는 유효하지 않습니다."),
     FAILED_TO_SAVE_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, "엔티티 저장에 실패했습니다."),
 

--- a/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
@@ -111,6 +111,7 @@ enum class ErrorCode(
     NOT_FOUND_ATTENDANCE(HttpStatus.NOT_FOUND, "ID가 %s인 출역현황을 찾을 수 없습니다."),
     NOT_FOUND_OBSERVATION(HttpStatus.NOT_FOUND, "ID가 %s인 드론 관측 데이터를 찾을 수 없습니다."),
 
+    MEDIA_SERVER_URL_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "미디어서버 URL이 설정되지 않았습니다."),
     EXCEED_FAVORITE_LIMIT(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 4개까지 추가할 수 있습니다."),
     ALREADY_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 이미 즐겨찾기되어 있습니다."),
     NOT_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 즐겨찾기가 아닙니다."),

--- a/src/main/kotlin/com/pluxity/siteguard/global/properties/MediaServerProperties.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/properties/MediaServerProperties.kt
@@ -1,0 +1,11 @@
+package com.pluxity.siteguard.global.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.ConstructorBinding
+
+@ConfigurationProperties(prefix = "media-server")
+data class MediaServerProperties
+    @ConstructorBinding
+    constructor(
+        val url: String,
+    )

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,3 +53,6 @@ logging:
 
 attendance:
   url: http://localhost:8080/docs/attendance
+
+media-server:
+  url: http://192.168.10.181:9997

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,4 +52,5 @@ springwolf: # socket documentation ui
 attendance:
   url: ${ATTENDANCE_API:http://localhost:8080/docs/attendance}
 
-  
+media-server:
+  url: ${MEDIA_SERVER_URL:http://192.168.10.181:9997}

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/entity/DummyEntities.kt
@@ -1,0 +1,19 @@
+package com.pluxity.siteguard.cctv.entity
+
+import com.pluxity.siteguard.base.entity.withAudit
+import com.pluxity.siteguard.base.entity.withId
+
+fun dummyCctv(
+    id: Long? = null,
+    path: String = "cam1",
+    name: String? = null,
+    lon: Double? = null,
+    lat: Double? = null,
+    isFavorite: Boolean = false,
+) = Cctv(
+    path = path,
+    name = name,
+    lon = lon,
+    lat = lat,
+    isFavorite = isFavorite,
+).withId(id).withAudit()

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvServiceTest.kt
@@ -1,0 +1,225 @@
+package com.pluxity.siteguard.cctv.service
+
+import com.pluxity.siteguard.cctv.client.CctvApiClient
+import com.pluxity.siteguard.cctv.dto.CctvUpdateRequest
+import com.pluxity.siteguard.cctv.dto.MediaServerPathItem
+import com.pluxity.siteguard.cctv.entity.Cctv
+import com.pluxity.siteguard.cctv.entity.dummyCctv
+import com.pluxity.siteguard.cctv.repository.CctvRepository
+import com.pluxity.siteguard.global.constant.ErrorCode
+import com.pluxity.siteguard.global.exception.CustomException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+
+class CctvServiceTest :
+    BehaviorSpec({
+
+        val repository: CctvRepository = mockk(relaxed = true)
+        val apiClient: CctvApiClient = mockk()
+        val service = CctvService(repository, apiClient)
+
+        Given("CCTV 동기화") {
+
+            When("미디어서버에 새로운 path가 있으면") {
+                val externalPaths =
+                    listOf(
+                        MediaServerPathItem(name = "cam1", confName = "conf1", ready = true),
+                        MediaServerPathItem(name = "cam2", confName = "conf2", ready = true),
+                    )
+
+                every { apiClient.fetchPaths() } returns externalPaths
+                every { repository.findAll() } returns emptyList()
+
+                service.sync()
+
+                Then("새로운 CCTV가 저장된다") {
+                    verify { repository.saveAll(match<List<Cctv>> { it.size == 2 }) }
+                }
+            }
+
+            When("DB에 있지만 미디어서버에 없는 path가 있으면") {
+                val existingCctv = dummyCctv(id = 1L, path = "cam_old")
+
+                every { apiClient.fetchPaths() } returns
+                    listOf(
+                        MediaServerPathItem(name = "cam_new", confName = "conf1", ready = true),
+                    )
+                every { repository.findAll() } returns listOf(existingCctv)
+
+                service.sync()
+
+                Then("해당 CCTV가 삭제된다") {
+                    verify { repository.deleteAllInBatch(match<List<Cctv>> { it.size == 1 && it[0].path == "cam_old" }) }
+                }
+            }
+
+            When("미디어서버와 DB가 동일하면") {
+                val existingCctv = dummyCctv(id = 1L, path = "cam1")
+
+                every { apiClient.fetchPaths() } returns
+                    listOf(
+                        MediaServerPathItem(name = "cam1", confName = "conf1", ready = true),
+                    )
+                every { repository.findAll() } returns listOf(existingCctv)
+
+                service.sync()
+
+                Then("저장이나 삭제가 수행되지 않는다") {
+                    verify(exactly = 0) { repository.saveAll(any<List<Cctv>>()) }
+                    verify(exactly = 0) { repository.deleteAllInBatch(any<List<Cctv>>()) }
+                }
+            }
+        }
+
+        Given("CCTV 목록 조회") {
+
+            When("CCTV 목록을 조회하면") {
+                val entities =
+                    listOf(
+                        dummyCctv(id = 1L, path = "cam1", name = "1번 카메라", isFavorite = true),
+                        dummyCctv(id = 2L, path = "cam2", name = "2번 카메라"),
+                    )
+
+                every { repository.findAllByOrderByIsFavoriteDescNameAsc() } returns entities
+
+                val result = service.findAll()
+
+                Then("목록이 반환된다") {
+                    result.size shouldBe 2
+                    result[0].isFavorite shouldBe true
+                    result[1].isFavorite shouldBe false
+                }
+            }
+
+            When("CCTV가 없으면") {
+                every { repository.findAllByOrderByIsFavoriteDescNameAsc() } returns emptyList()
+
+                val result = service.findAll()
+
+                Then("빈 목록이 반환된다") {
+                    result.size shouldBe 0
+                }
+            }
+        }
+
+        Given("CCTV 수정") {
+
+            When("존재하는 CCTV를 수정하면") {
+                val entity = dummyCctv(id = 1L, path = "cam1")
+                val request = CctvUpdateRequest(name = "1번 카메라", lon = 127.0, lat = 37.0)
+
+                every { repository.findByIdOrNull(1L) } returns entity
+
+                service.update(1L, request)
+
+                Then("name, lon, lat이 수정된다") {
+                    entity.name shouldBe "1번 카메라"
+                    entity.lon shouldBe 127.0
+                    entity.lat shouldBe 37.0
+                }
+            }
+
+            When("존재하지 않는 CCTV를 수정하면") {
+                every { repository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CCTV 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.update(999L, CctvUpdateRequest(name = "test", lon = null, lat = null))
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV
+                }
+            }
+        }
+
+        Given("즐겨찾기 추가") {
+
+            When("즐겨찾기가 아닌 CCTV에 추가하면") {
+                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = false)
+
+                every { repository.findByIdOrNull(1L) } returns entity
+                every { repository.countByIsFavoriteTrue() } returns 2
+
+                service.addFavorite(1L)
+
+                Then("즐겨찾기가 설정된다") {
+                    entity.isFavorite shouldBe true
+                }
+            }
+
+            When("이미 즐겨찾기인 CCTV에 추가하면") {
+                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = true)
+
+                every { repository.findByIdOrNull(1L) } returns entity
+
+                Then("ALREADY_FAVORITE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.addFavorite(1L)
+                        }
+                    exception.errorCode shouldBe ErrorCode.ALREADY_FAVORITE
+                }
+            }
+
+            When("즐겨찾기가 4개인 상태에서 추가하면") {
+                val entity = dummyCctv(id = 5L, path = "cam5", isFavorite = false)
+
+                every { repository.findByIdOrNull(5L) } returns entity
+                every { repository.countByIsFavoriteTrue() } returns 4
+
+                Then("EXCEED_FAVORITE_LIMIT 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.addFavorite(5L)
+                        }
+                    exception.errorCode shouldBe ErrorCode.EXCEED_FAVORITE_LIMIT
+                }
+            }
+        }
+
+        Given("즐겨찾기 해제") {
+
+            When("즐겨찾기인 CCTV를 해제하면") {
+                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = true)
+
+                every { repository.findByIdOrNull(1L) } returns entity
+
+                service.removeFavorite(1L)
+
+                Then("즐겨찾기가 해제된다") {
+                    entity.isFavorite shouldBe false
+                }
+            }
+
+            When("즐겨찾기가 아닌 CCTV를 해제하면") {
+                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = false)
+
+                every { repository.findByIdOrNull(1L) } returns entity
+
+                Then("NOT_FAVORITE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.removeFavorite(1L)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FAVORITE
+                }
+            }
+
+            When("존재하지 않는 CCTV를 해제하면") {
+                every { repository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CCTV 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.removeFavorite(999L)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV
+                }
+            }
+        }
+    })


### PR DESCRIPTION
## 요약
- 미디어서버(`/v3/paths/list`)에서 CCTV 경로 목록을 가져와 DB에 동기화하는 기능 구현
- CCTV 이름/좌표 수정 및 즐겨찾기(최대 4개) 관리 API 추가
- `media-server.url` 설정 추가 (local, prod)
## 이슈 넘버 or 관련 링크

## 변경사항 🏗️
## API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/cctvs/sync` | 미디어서버 동기화 |
| GET | `/cctvs` | 목록 조회 (즐겨찾기 우선, 이름순) |
| PATCH | `/cctvs/{id}` | 이름/경도/위도 수정 |
| POST | `/cctvs/{id}/favorite` | 즐겨찾기 추가 |
| DELETE | `/cctvs/{id}/favorite` | 즐겨찾기 해제 |

## 변경 파일
- `cctv/` 패키지 신규 생성 (Entity, Repository, Service, Controller, DTO, Client)
- `MediaServerProperties` 추가
- `ErrorCode`에 즐겨찾기 관련 에러코드 3건 추가
<!-- 변경 사항에 대해서 기재 필요 -->

### Checklist 📋

## 코드 변경 사항

- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
