### PR TITLE
feat: 시스템설정에 BIM 썸네일/조감도 파일 관리 기능 추가

### DIFF
--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/dto/SystemSettingRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/dto/SystemSettingRequest.kt
@@ -8,4 +8,8 @@ data class SystemSettingRequest(
     @field:Min(value = 1, message = "롤링 간격은 1초 이상이어야 합니다.")
     @field:Schema(description = "롤링 간격(초)", example = "10")
     val rollingIntervalSeconds: Int,
+    @field:Schema(description = "BIM 썸네일 파일 ID", example = "1")
+    val bimThumbnailFileId: Long? = null,
+    @field:Schema(description = "조감도 파일 ID", example = "2")
+    val aerialViewFileId: Long? = null,
 )

--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/dto/SystemSettingResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/dto/SystemSettingResponse.kt
@@ -1,5 +1,6 @@
 package com.pluxity.siteguard.systemsetting.dto
 
+import com.pluxity.siteguard.file.dto.FileResponse
 import com.pluxity.siteguard.systemsetting.entity.SystemSetting
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -7,9 +8,18 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class SystemSettingResponse(
     @field:Schema(description = "롤링 간격(초)")
     val rollingIntervalSeconds: Int? = null,
+    @field:Schema(description = "BIM 썸네일 파일 정보")
+    val bimThumbnailFile: FileResponse = FileResponse(),
+    @field:Schema(description = "조감도 파일 정보")
+    val aerialViewFile: FileResponse = FileResponse(),
 )
 
-fun SystemSetting.toResponse(): SystemSettingResponse =
+fun SystemSetting.toResponse(
+    bimThumbnailFile: FileResponse? = null,
+    aerialViewFile: FileResponse? = null,
+): SystemSettingResponse =
     SystemSettingResponse(
         rollingIntervalSeconds = rollingIntervalSeconds,
+        bimThumbnailFile = bimThumbnailFile ?: FileResponse(),
+        aerialViewFile = aerialViewFile ?: FileResponse(),
     )

--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/entity/SystemSetting.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/entity/SystemSetting.kt
@@ -14,9 +14,19 @@ class SystemSetting(
     val id: Long = SINGLETON_ID,
     @Column(name = "rolling_interval_seconds", nullable = false)
     var rollingIntervalSeconds: Int,
+    @Column(name = "bim_thumbnail_file_id")
+    var bimThumbnailFileId: Long? = null,
+    @Column(name = "aerial_view_file_id")
+    var aerialViewFileId: Long? = null,
 ) : BaseEntity() {
-    fun update(rollingIntervalSeconds: Int) {
+    fun update(
+        rollingIntervalSeconds: Int,
+        bimThumbnailFileId: Long?,
+        aerialViewFileId: Long?,
+    ) {
         this.rollingIntervalSeconds = rollingIntervalSeconds
+        this.bimThumbnailFileId = bimThumbnailFileId
+        this.aerialViewFileId = aerialViewFileId
     }
 
     companion object {

--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
@@ -32,9 +32,12 @@ class SystemSettingService(
 
     @Transactional
     fun update(request: SystemSettingRequest) {
+        val existing = systemSettingRepository.findByIdOrNull(SystemSetting.SINGLETON_ID)
+        val previousBimFileId = existing?.bimThumbnailFileId
+        val previousAerialFileId = existing?.aerialViewFileId
+
         val setting =
-            systemSettingRepository
-                .findByIdOrNull(SystemSetting.SINGLETON_ID)
+            existing
                 ?.apply {
                     update(
                         rollingIntervalSeconds = request.rollingIntervalSeconds,
@@ -50,11 +53,17 @@ class SystemSettingService(
                     ),
                 )
 
-        request.bimThumbnailFileId?.let {
-            fileService.finalizeUpload(it, "$BIM_THUMBNAIL_PATH${setting.id}/")
-        }
-        request.aerialViewFileId?.let {
-            fileService.finalizeUpload(it, "$AERIAL_VIEW_PATH${setting.id}/")
+        finalizeIfChanged(previousBimFileId, request.bimThumbnailFileId, "$BIM_THUMBNAIL_PATH${setting.id}/")
+        finalizeIfChanged(previousAerialFileId, request.aerialViewFileId, "$AERIAL_VIEW_PATH${setting.id}/")
+    }
+
+    private fun finalizeIfChanged(
+        previousFileId: Long?,
+        newFileId: Long?,
+        path: String,
+    ) {
+        if (newFileId != null && newFileId != previousFileId) {
+            fileService.finalizeUpload(newFileId, path)
         }
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
@@ -32,12 +32,9 @@ class SystemSettingService(
 
     @Transactional
     fun update(request: SystemSettingRequest) {
-        val existing = systemSettingRepository.findByIdOrNull(SystemSetting.SINGLETON_ID)
-        val previousBimFileId = existing?.bimThumbnailFileId
-        val previousAerialFileId = existing?.aerialViewFileId
-
         val setting =
-            existing
+            systemSettingRepository
+                .findByIdOrNull(SystemSetting.SINGLETON_ID)
                 ?.apply {
                     update(
                         rollingIntervalSeconds = request.rollingIntervalSeconds,
@@ -53,17 +50,11 @@ class SystemSettingService(
                     ),
                 )
 
-        finalizeIfChanged(previousBimFileId, request.bimThumbnailFileId, "$BIM_THUMBNAIL_PATH${setting.id}/")
-        finalizeIfChanged(previousAerialFileId, request.aerialViewFileId, "$AERIAL_VIEW_PATH${setting.id}/")
-    }
-
-    private fun finalizeIfChanged(
-        previousFileId: Long?,
-        newFileId: Long?,
-        path: String,
-    ) {
-        if (newFileId != null && newFileId != previousFileId) {
-            fileService.finalizeUpload(newFileId, path)
+        request.bimThumbnailFileId?.let {
+            fileService.finalizeUpload(it, "$BIM_THUMBNAIL_PATH${setting.id}/")
+        }
+        request.aerialViewFileId?.let {
+            fileService.finalizeUpload(it, "$AERIAL_VIEW_PATH${setting.id}/")
         }
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingService.kt
@@ -1,5 +1,6 @@
 package com.pluxity.siteguard.systemsetting.service
 
+import com.pluxity.siteguard.file.service.FileService
 import com.pluxity.siteguard.systemsetting.dto.SystemSettingRequest
 import com.pluxity.siteguard.systemsetting.dto.SystemSettingResponse
 import com.pluxity.siteguard.systemsetting.dto.toResponse
@@ -13,16 +14,47 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class SystemSettingService(
     private val systemSettingRepository: SystemSettingRepository,
+    private val fileService: FileService,
 ) {
-    fun find(): SystemSettingResponse =
-        systemSettingRepository.findByIdOrNull(SystemSetting.SINGLETON_ID)?.toResponse()
-            ?: SystemSettingResponse()
+    companion object {
+        private const val BIM_THUMBNAIL_PATH = "system-settings/bim-thumbnail/"
+        private const val AERIAL_VIEW_PATH = "system-settings/aerial-view/"
+    }
+
+    fun find(): SystemSettingResponse {
+        val setting =
+            systemSettingRepository.findByIdOrNull(SystemSetting.SINGLETON_ID)
+                ?: return SystemSettingResponse()
+        val bimThumbnailFile = fileService.getFileResponse(setting.bimThumbnailFileId)
+        val aerialViewFile = fileService.getFileResponse(setting.aerialViewFileId)
+        return setting.toResponse(bimThumbnailFile, aerialViewFile)
+    }
 
     @Transactional
     fun update(request: SystemSettingRequest) {
-        systemSettingRepository
-            .findByIdOrNull(SystemSetting.SINGLETON_ID)
-            ?.apply { update(request.rollingIntervalSeconds) }
-            ?: systemSettingRepository.save(SystemSetting(rollingIntervalSeconds = request.rollingIntervalSeconds))
+        val setting =
+            systemSettingRepository
+                .findByIdOrNull(SystemSetting.SINGLETON_ID)
+                ?.apply {
+                    update(
+                        rollingIntervalSeconds = request.rollingIntervalSeconds,
+                        bimThumbnailFileId = request.bimThumbnailFileId,
+                        aerialViewFileId = request.aerialViewFileId,
+                    )
+                }
+                ?: systemSettingRepository.save(
+                    SystemSetting(
+                        rollingIntervalSeconds = request.rollingIntervalSeconds,
+                        bimThumbnailFileId = request.bimThumbnailFileId,
+                        aerialViewFileId = request.aerialViewFileId,
+                    ),
+                )
+
+        request.bimThumbnailFileId?.let {
+            fileService.finalizeUpload(it, "$BIM_THUMBNAIL_PATH${setting.id}/")
+        }
+        request.aerialViewFileId?.let {
+            fileService.finalizeUpload(it, "$AERIAL_VIEW_PATH${setting.id}/")
+        }
     }
 }

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/dto/DummyDTOs.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/dto/DummyDTOs.kt
@@ -1,6 +1,11 @@
 package com.pluxity.siteguard.systemsetting.dto
 
-fun dummySystemSettingRequest(rollingIntervalSeconds: Int = 10) =
-    SystemSettingRequest(
-        rollingIntervalSeconds = rollingIntervalSeconds,
-    )
+fun dummySystemSettingRequest(
+    rollingIntervalSeconds: Int = 10,
+    bimThumbnailFileId: Long? = null,
+    aerialViewFileId: Long? = null,
+) = SystemSettingRequest(
+    rollingIntervalSeconds = rollingIntervalSeconds,
+    bimThumbnailFileId = bimThumbnailFileId,
+    aerialViewFileId = aerialViewFileId,
+)

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/entity/DummyEntities.kt
@@ -2,7 +2,12 @@ package com.pluxity.siteguard.systemsetting.entity
 
 import com.pluxity.siteguard.base.entity.withAudit
 
-fun dummySystemSetting(rollingIntervalSeconds: Int = 10) =
-    SystemSetting(
-        rollingIntervalSeconds = rollingIntervalSeconds,
-    ).withAudit()
+fun dummySystemSetting(
+    rollingIntervalSeconds: Int = 10,
+    bimThumbnailFileId: Long? = null,
+    aerialViewFileId: Long? = null,
+) = SystemSetting(
+    rollingIntervalSeconds = rollingIntervalSeconds,
+    bimThumbnailFileId = bimThumbnailFileId,
+    aerialViewFileId = aerialViewFileId,
+).withAudit()

--- a/src/test/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/systemsetting/service/SystemSettingServiceTest.kt
@@ -1,5 +1,6 @@
 package com.pluxity.siteguard.systemsetting.service
 
+import com.pluxity.siteguard.file.service.FileService
 import com.pluxity.siteguard.systemsetting.dto.dummySystemSettingRequest
 import com.pluxity.siteguard.systemsetting.entity.SystemSetting
 import com.pluxity.siteguard.systemsetting.entity.dummySystemSetting
@@ -15,7 +16,8 @@ class SystemSettingServiceTest :
     BehaviorSpec({
 
         val repository: SystemSettingRepository = mockk(relaxed = true)
-        val service = SystemSettingService(repository)
+        val fileService: FileService = mockk(relaxed = true)
+        val service = SystemSettingService(repository, fileService)
 
         Given("시스템 설정 조회") {
 
@@ -23,6 +25,7 @@ class SystemSettingServiceTest :
                 val entity = dummySystemSetting(rollingIntervalSeconds = 15)
 
                 every { repository.findByIdOrNull(SystemSetting.SINGLETON_ID) } returns entity
+                every { fileService.getFileResponse(any()) } returns null
 
                 val result = service.find()
 


### PR DESCRIPTION
## 요약
- 시스템설정 엔티티에 BIM 썸네일(`bimThumbnailFileId`), 조감도(`aerialViewFileId`) 파일 ID 필드 추가
  - 설정 수정 시 해당 파일을 `finalizeUpload`하여 TEMP → COMPLETE 상태로 전환
  - 조회 시 파일 정보(`FileResponse`)를 함께 반환
## 이슈 넘버 or 관련 링크

## 변경사항 🏗️
- `SystemSetting` 엔티티에 `bimThumbnailFileId`, `aerialViewFileId` 컬럼 추가                                                                                
  - `SystemSettingService`에 `FileService` 의존성 추가 및 finalize 로직 구현
  - `SystemSettingResponse`에 `FileResponse` 포함 (기본값 빈 객체)
  - 기존 단위테스트에 `FileService` mock 반영
<!-- 변경 사항에 대해서 기재 필요 -->

### Checklist 📋

## 코드 변경 사항

- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
