### PR TITLE
refactor: CCTV 즐겨찾기를 별도 엔티티로 분리 및 path를 streamName으로 변경

### DIFF
--- a/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
@@ -49,7 +49,7 @@ class CctvController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "CCTV 목록 조회", description = "CCTV 목록을 이름순으로 조회합니다")
+    @Operation(summary = "CCTV 목록 조회", description = "CCTV 목록을 조회합니다 (즐겨찾기 우선, 이름순 정렬)")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "조회 성공"),

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvController.kt
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -50,7 +49,7 @@ class CctvController(
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "CCTV 목록 조회", description = "CCTV 목록을 조회합니다 (즐겨찾기 우선, 이름순 정렬)")
+    @Operation(summary = "CCTV 목록 조회", description = "CCTV 목록을 이름순으로 조회합니다")
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -91,74 +90,6 @@ class CctvController(
         @RequestBody @Valid request: CctvUpdateRequest,
     ): ResponseEntity<Void> {
         service.update(id, request)
-        return ResponseEntity.noContent().build()
-    }
-
-    @Operation(summary = "CCTV 즐겨찾기 추가", description = "CCTV를 즐겨찾기에 추가합니다 (최대 4개)")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "204", description = "즐겨찾기 추가 성공"),
-            ApiResponse(
-                responseCode = "400",
-                description = "즐겨찾기 최대 개수 초과 또는 이미 즐겨찾기된 CCTV",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ErrorResponseBody::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "CCTV를 찾을 수 없음",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ErrorResponseBody::class),
-                    ),
-                ],
-            ),
-        ],
-    )
-    @PostMapping("/{id}/favorite")
-    fun addFavorite(
-        @PathVariable id: Long,
-    ): ResponseEntity<Void> {
-        service.addFavorite(id)
-        return ResponseEntity.noContent().build()
-    }
-
-    @Operation(summary = "CCTV 즐겨찾기 해제", description = "CCTV의 즐겨찾기를 해제합니다")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "204", description = "즐겨찾기 해제 성공"),
-            ApiResponse(
-                responseCode = "400",
-                description = "즐겨찾기가 아닌 CCTV",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ErrorResponseBody::class),
-                    ),
-                ],
-            ),
-            ApiResponse(
-                responseCode = "404",
-                description = "CCTV를 찾을 수 없음",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ErrorResponseBody::class),
-                    ),
-                ],
-            ),
-        ],
-    )
-    @DeleteMapping("/{id}/favorite")
-    fun removeFavorite(
-        @PathVariable id: Long,
-    ): ResponseEntity<Void> {
-        service.removeFavorite(id)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvFavoriteController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvFavoriteController.kt
@@ -1,0 +1,94 @@
+package com.pluxity.siteguard.cctv.controller
+
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteOrderRequest
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteRequest
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteResponse
+import com.pluxity.siteguard.cctv.service.CctvFavoriteService
+import com.pluxity.siteguard.global.response.DataResponseBody
+import com.pluxity.siteguard.global.response.ErrorResponseBody
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/cctv-favorites")
+@Tag(name = "CCTV Controller", description = "CCTV 관리 API")
+class CctvFavoriteController(
+    private val service: CctvFavoriteService,
+) {
+    @Operation(summary = "CCTV 즐겨찾기 목록 조회", description = "즐겨찾기 등록된 CCTV 목록을 표시 순서대로 조회합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "조회 성공"),
+        ],
+    )
+    @GetMapping
+    fun findAll(): ResponseEntity<DataResponseBody<List<CctvFavoriteResponse>>> = ResponseEntity.ok(DataResponseBody(service.findAll()))
+
+    @Operation(summary = "CCTV 즐겨찾기 등록", description = "CCTV를 즐겨찾기에 등록합니다 (최대 4개)")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "등록 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "즐겨찾기 최대 개수 초과 또는 이미 즐겨찾기된 CCTV",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PostMapping
+    fun create(
+        @RequestBody @Valid request: CctvFavoriteRequest,
+    ): ResponseEntity<DataResponseBody<Long>> = ResponseEntity.ok(DataResponseBody(service.create(request)))
+
+    @Operation(summary = "CCTV 즐겨찾기 삭제", description = "CCTV 즐겨찾기를 삭제합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "삭제 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "즐겨찾기를 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        service.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "CCTV 즐겨찾기 순서 변경", description = "즐겨찾기의 표시 순서를 변경합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "204", description = "순서 변경 성공"),
+            ApiResponse(
+                responseCode = "404",
+                description = "즐겨찾기를 찾을 수 없음",
+                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+            ),
+        ],
+    )
+    @PatchMapping("/order")
+    fun updateOrder(
+        @RequestBody @Valid request: CctvFavoriteOrderRequest,
+    ): ResponseEntity<Void> {
+        service.updateOrder(request)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvFavoriteController.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/controller/CctvFavoriteController.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/cctv-favorites")
-@Tag(name = "CCTV Controller", description = "CCTV 관리 API")
+@Tag(name = "CCTV Favorite Controller", description = "CCTV 즐겨찾기 관리 API")
 class CctvFavoriteController(
     private val service: CctvFavoriteService,
 ) {
@@ -45,7 +45,12 @@ class CctvFavoriteController(
             ApiResponse(
                 responseCode = "400",
                 description = "즐겨찾기 최대 개수 초과 또는 이미 즐겨찾기된 CCTV",
-                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -61,7 +66,12 @@ class CctvFavoriteController(
             ApiResponse(
                 responseCode = "404",
                 description = "즐겨찾기를 찾을 수 없음",
-                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )
@@ -80,7 +90,12 @@ class CctvFavoriteController(
             ApiResponse(
                 responseCode = "404",
                 description = "즐겨찾기를 찾을 수 없음",
-                content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponseBody::class))],
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
             ),
         ],
     )

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvFavoriteRequest.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvFavoriteRequest.kt
@@ -1,0 +1,17 @@
+package com.pluxity.siteguard.cctv.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "CCTV 즐겨찾기 등록 요청")
+data class CctvFavoriteRequest(
+    @field:NotBlank(message = "CCTV 스트림명은 필수입니다")
+    @field:Schema(description = "CCTV 스트림명", example = "CCTV-001")
+    val streamName: String,
+)
+
+@Schema(description = "CCTV 즐겨찾기 순서 변경 요청")
+data class CctvFavoriteOrderRequest(
+    @field:Schema(description = "순서대로 정렬된 즐겨찾기 ID 목록", example = "[1, 3, 2, 4]")
+    val ids: List<Long>,
+)

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvFavoriteResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvFavoriteResponse.kt
@@ -1,0 +1,28 @@
+package com.pluxity.siteguard.cctv.dto
+
+import com.pluxity.siteguard.cctv.entity.CctvFavorite
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "CCTV 즐겨찾기 응답")
+data class CctvFavoriteResponse(
+    @field:Schema(description = "ID", example = "1")
+    val id: Long,
+    @field:Schema(description = "CCTV 스트림명", example = "CCTV-001")
+    val streamName: String,
+    @field:Schema(description = "표시 순서", example = "1")
+    val displayOrder: Int,
+    @field:Schema(description = "생성일시")
+    val createdAt: LocalDateTime,
+    @field:Schema(description = "생성자")
+    val createdBy: String?,
+)
+
+fun CctvFavorite.toResponse(): CctvFavoriteResponse =
+    CctvFavoriteResponse(
+        id = this.requiredId,
+        streamName = this.streamName,
+        displayOrder = this.displayOrder,
+        createdAt = this.createdAt,
+        createdBy = this.createdBy,
+    )

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvResponse.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/dto/CctvResponse.kt
@@ -10,16 +10,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class CctvResponse(
     @field:Schema(description = "ID", example = "1")
     val id: Long,
-    @field:Schema(description = "경로", example = "cam1")
-    val path: String,
+    @field:Schema(description = "스트림명", example = "cam1")
+    val streamName: String,
     @field:Schema(description = "이름", example = "1번 카메라")
     val name: String?,
     @field:Schema(description = "경도", example = "127.0")
     val lon: Double?,
     @field:Schema(description = "위도", example = "37.0")
     val lat: Double?,
-    @field:Schema(description = "즐겨찾기 여부", example = "false")
-    val isFavorite: Boolean,
     @field:JsonUnwrapped
     val baseResponse: BaseResponse,
 )
@@ -27,10 +25,9 @@ data class CctvResponse(
 fun Cctv.toResponse(): CctvResponse =
     CctvResponse(
         id = this.requiredId,
-        path = this.path,
+        streamName = this.streamName,
         name = this.name,
         lon = this.lon,
         lat = this.lat,
-        isFavorite = this.isFavorite,
         baseResponse = this.toBaseResponse(),
     )

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/entity/Cctv.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/entity/Cctv.kt
@@ -4,22 +4,18 @@ import com.pluxity.siteguard.global.entity.IdentityIdEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
-import org.hibernate.annotations.ColumnDefault
 
 @Entity
 @Table(name = "cctv_stream")
 class Cctv(
-    @Column(name = "path", nullable = false, unique = true)
-    val path: String,
+    @Column(name = "stream_name", nullable = false, unique = true)
+    val streamName: String,
     @Column(name = "name")
     var name: String? = null,
     @Column(name = "lon")
     var lon: Double? = null,
     @Column(name = "lat")
     var lat: Double? = null,
-    @Column(name = "is_favorite", nullable = false)
-    @ColumnDefault("false")
-    var isFavorite: Boolean = false,
 ) : IdentityIdEntity() {
     fun update(
         name: String?,
@@ -29,13 +25,5 @@ class Cctv(
         this.name = name
         this.lon = lon
         this.lat = lat
-    }
-
-    fun markFavorite() {
-        this.isFavorite = true
-    }
-
-    fun unmarkFavorite() {
-        this.isFavorite = false
     }
 }

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/entity/CctvFavorite.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/entity/CctvFavorite.kt
@@ -1,0 +1,25 @@
+package com.pluxity.siteguard.cctv.entity
+
+import com.pluxity.siteguard.global.entity.IdentityIdEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "cctv_favorite",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_cctv_favorite_stream_name", columnNames = ["stream_name"]),
+    ],
+)
+class CctvFavorite(
+    @Column(name = "stream_name", nullable = false)
+    val streamName: String,
+    @Column(name = "display_order", nullable = false)
+    var displayOrder: Int,
+) : IdentityIdEntity() {
+    fun updateDisplayOrder(displayOrder: Int) {
+        this.displayOrder = displayOrder
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvFavoriteRepository.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvFavoriteRepository.kt
@@ -1,0 +1,10 @@
+package com.pluxity.siteguard.cctv.repository
+
+import com.pluxity.siteguard.cctv.entity.CctvFavorite
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CctvFavoriteRepository : JpaRepository<CctvFavorite, Long> {
+    fun findAllByOrderByDisplayOrderAsc(): List<CctvFavorite>
+
+    fun existsByStreamName(streamName: String): Boolean
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvRepository.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/repository/CctvRepository.kt
@@ -3,8 +3,4 @@ package com.pluxity.siteguard.cctv.repository
 import com.pluxity.siteguard.cctv.entity.Cctv
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CctvRepository : JpaRepository<Cctv, Long> {
-    fun countByIsFavoriteTrue(): Long
-
-    fun findAllByOrderByIsFavoriteDescNameAsc(): List<Cctv>
-}
+interface CctvRepository : JpaRepository<Cctv, Long>

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteService.kt
@@ -51,6 +51,10 @@ class CctvFavoriteService(
 
     @Transactional
     fun updateOrder(request: CctvFavoriteOrderRequest) {
+        val totalCount = repository.count()
+        if (request.ids.size.toLong() != totalCount) {
+            throw CustomException(ErrorCode.INVALID_FAVORITE_ORDER_COUNT)
+        }
         val favorites = repository.findAllById(request.ids).associateBy { it.requiredId }
         request.ids.forEachIndexed { index, id ->
             val favorite =

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteService.kt
@@ -1,0 +1,62 @@
+package com.pluxity.siteguard.cctv.service
+
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteOrderRequest
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteRequest
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteResponse
+import com.pluxity.siteguard.cctv.dto.toResponse
+import com.pluxity.siteguard.cctv.entity.CctvFavorite
+import com.pluxity.siteguard.cctv.repository.CctvFavoriteRepository
+import com.pluxity.siteguard.global.constant.ErrorCode
+import com.pluxity.siteguard.global.exception.CustomException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class CctvFavoriteService(
+    private val repository: CctvFavoriteRepository,
+) {
+    companion object {
+        private const val MAX_FAVORITE_COUNT = 4
+    }
+
+    fun findAll(): List<CctvFavoriteResponse> = repository.findAllByOrderByDisplayOrderAsc().map { it.toResponse() }
+
+    @Transactional
+    fun create(request: CctvFavoriteRequest): Long {
+        if (repository.existsByStreamName(request.streamName)) {
+            throw CustomException(ErrorCode.ALREADY_FAVORITE, request.streamName)
+        }
+        val count = repository.count()
+        if (count >= MAX_FAVORITE_COUNT) {
+            throw CustomException(ErrorCode.EXCEED_FAVORITE_LIMIT)
+        }
+        return repository
+            .save(
+                CctvFavorite(
+                    streamName = request.streamName,
+                    displayOrder = (count + 1).toInt(),
+                ),
+            ).requiredId
+    }
+
+    @Transactional
+    fun delete(id: Long) {
+        val favorite =
+            repository.findByIdOrNull(id)
+                ?: throw CustomException(ErrorCode.NOT_FOUND_CCTV_FAVORITE, id)
+        repository.delete(favorite)
+    }
+
+    @Transactional
+    fun updateOrder(request: CctvFavoriteOrderRequest) {
+        val favorites = repository.findAllById(request.ids).associateBy { it.requiredId }
+        request.ids.forEachIndexed { index, id ->
+            val favorite =
+                favorites[id]
+                    ?: throw CustomException(ErrorCode.NOT_FOUND_CCTV_FAVORITE, id)
+            favorite.updateDisplayOrder(index + 1)
+        }
+    }
+}

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
@@ -5,6 +5,7 @@ import com.pluxity.siteguard.cctv.dto.CctvResponse
 import com.pluxity.siteguard.cctv.dto.CctvUpdateRequest
 import com.pluxity.siteguard.cctv.dto.toResponse
 import com.pluxity.siteguard.cctv.entity.Cctv
+import com.pluxity.siteguard.cctv.repository.CctvFavoriteRepository
 import com.pluxity.siteguard.cctv.repository.CctvRepository
 import com.pluxity.siteguard.global.constant.ErrorCode
 import com.pluxity.siteguard.global.exception.CustomException
@@ -16,41 +17,46 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class CctvService(
     private val repository: CctvRepository,
+    private val favoriteRepository: CctvFavoriteRepository,
     private val apiClient: CctvApiClient,
 ) {
-    companion object {
-        private const val MAX_FAVORITE_COUNT = 4
-    }
-
     @Transactional
     fun sync() {
         val externalPaths = apiClient.fetchPaths()
         val externalPathNames = externalPaths.map { it.name }
 
         val existingCctvs = repository.findAll()
-        val existingPathMap = existingCctvs.associateBy { it.path }
+        val existingStreamNameMap = existingCctvs.associateBy { it.streamName }
 
-        // 새로운 path → Cctv 엔티티 생성 후 저장
         val newCctvs =
             externalPathNames
-                .filter { it !in existingPathMap }
-                .map { Cctv(path = it) }
+                .filter { it !in existingStreamNameMap }
+                .map { Cctv(streamName = it) }
         if (newCctvs.isNotEmpty()) {
             repository.saveAll(newCctvs)
         }
 
-        // DB에 있지만 미디어서버에 없는 path → 삭제
         val externalPathSet = externalPathNames.toSet()
-        val toDelete = existingCctvs.filter { it.path !in externalPathSet }
+        val toDelete = existingCctvs.filter { it.streamName !in externalPathSet }
         if (toDelete.isNotEmpty()) {
             repository.deleteAllInBatch(toDelete)
         }
     }
 
-    fun findAll(): List<CctvResponse> =
-        repository
-            .findAllByOrderByIsFavoriteDescNameAsc()
-            .map { it.toResponse() }
+    fun findAll(): List<CctvResponse> {
+        val favorites = favoriteRepository.findAllByOrderByDisplayOrderAsc()
+        val favoriteStreamNames = favorites.map { it.streamName }
+
+        val cctvMap = repository.findAll().associateBy { it.streamName }
+
+        val favoriteCctvs = favoriteStreamNames.mapNotNull { cctvMap[it] }
+        val nonFavoriteCctvs =
+            cctvMap.values
+                .filter { it.streamName !in favoriteStreamNames.toSet() }
+                .sortedBy { it.name }
+
+        return (favoriteCctvs + nonFavoriteCctvs).map { it.toResponse() }
+    }
 
     @Transactional
     fun update(
@@ -62,27 +68,6 @@ class CctvService(
             lon = request.lon,
             lat = request.lat,
         )
-    }
-
-    @Transactional
-    fun addFavorite(id: Long) {
-        val cctv = getById(id)
-        if (cctv.isFavorite) {
-            throw CustomException(ErrorCode.ALREADY_FAVORITE, id)
-        }
-        if (repository.countByIsFavoriteTrue() >= MAX_FAVORITE_COUNT) {
-            throw CustomException(ErrorCode.EXCEED_FAVORITE_LIMIT)
-        }
-        cctv.markFavorite()
-    }
-
-    @Transactional
-    fun removeFavorite(id: Long) {
-        val cctv = getById(id)
-        if (!cctv.isFavorite) {
-            throw CustomException(ErrorCode.NOT_FAVORITE, id)
-        }
-        cctv.unmarkFavorite()
     }
 
     private fun getById(id: Long): Cctv =

--- a/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/cctv/service/CctvService.kt
@@ -45,14 +45,14 @@ class CctvService(
 
     fun findAll(): List<CctvResponse> {
         val favorites = favoriteRepository.findAllByOrderByDisplayOrderAsc()
-        val favoriteStreamNames = favorites.map { it.streamName }
+        val favoriteStreamNames = favorites.map { it.streamName }.toSet()
 
         val cctvMap = repository.findAll().associateBy { it.streamName }
 
         val favoriteCctvs = favoriteStreamNames.mapNotNull { cctvMap[it] }
         val nonFavoriteCctvs =
             cctvMap.values
-                .filter { it.streamName !in favoriteStreamNames.toSet() }
+                .filter { it.streamName !in favoriteStreamNames }
                 .sortedBy { it.name }
 
         return (favoriteCctvs + nonFavoriteCctvs).map { it.toResponse() }

--- a/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
@@ -114,6 +114,7 @@ enum class ErrorCode(
     MEDIA_SERVER_URL_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "미디어서버 URL이 설정되지 않았습니다."),
     EXCEED_FAVORITE_LIMIT(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 4개까지 추가할 수 있습니다."),
     ALREADY_FAVORITE(HttpStatus.BAD_REQUEST, "스트림명이 %s인 CCTV는 이미 즐겨찾기되어 있습니다."),
+    INVALID_FAVORITE_ORDER_COUNT(HttpStatus.BAD_REQUEST, "즐겨찾기 순서 변경은 전체 즐겨찾기를 대상으로 해야 합니다."),
     NOT_FOUND_CCTV_FAVORITE(HttpStatus.NOT_FOUND, "ID가 %s인 CCTV 즐겨찾기를 찾을 수 없습니다."),
 
     INVALID_RESOURCE_IDS_INCLUDED(HttpStatus.BAD_REQUEST, "요청한 리소스 ID %s 는 유효하지 않습니다."),

--- a/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
+++ b/src/main/kotlin/com/pluxity/siteguard/global/constant/ErrorCode.kt
@@ -113,8 +113,8 @@ enum class ErrorCode(
 
     MEDIA_SERVER_URL_NOT_CONFIGURED(HttpStatus.INTERNAL_SERVER_ERROR, "미디어서버 URL이 설정되지 않았습니다."),
     EXCEED_FAVORITE_LIMIT(HttpStatus.BAD_REQUEST, "즐겨찾기는 최대 4개까지 추가할 수 있습니다."),
-    ALREADY_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 이미 즐겨찾기되어 있습니다."),
-    NOT_FAVORITE(HttpStatus.BAD_REQUEST, "ID가 %s인 CCTV는 즐겨찾기가 아닙니다."),
+    ALREADY_FAVORITE(HttpStatus.BAD_REQUEST, "스트림명이 %s인 CCTV는 이미 즐겨찾기되어 있습니다."),
+    NOT_FOUND_CCTV_FAVORITE(HttpStatus.NOT_FOUND, "ID가 %s인 CCTV 즐겨찾기를 찾을 수 없습니다."),
 
     INVALID_RESOURCE_IDS_INCLUDED(HttpStatus.BAD_REQUEST, "요청한 리소스 ID %s 는 유효하지 않습니다."),
     FAILED_TO_SAVE_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, "엔티티 저장에 실패했습니다."),

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/entity/DummyEntities.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/entity/DummyEntities.kt
@@ -5,15 +5,22 @@ import com.pluxity.siteguard.base.entity.withId
 
 fun dummyCctv(
     id: Long? = null,
-    path: String = "cam1",
+    streamName: String = "cam1",
     name: String? = null,
     lon: Double? = null,
     lat: Double? = null,
-    isFavorite: Boolean = false,
 ) = Cctv(
-    path = path,
+    streamName = streamName,
     name = name,
     lon = lon,
     lat = lat,
-    isFavorite = isFavorite,
+).withId(id).withAudit()
+
+fun dummyCctvFavorite(
+    id: Long? = null,
+    streamName: String = "cam1",
+    displayOrder: Int = 1,
+) = CctvFavorite(
+    streamName = streamName,
+    displayOrder = displayOrder,
 ).withId(id).withAudit()

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteServiceTest.kt
@@ -1,0 +1,160 @@
+package com.pluxity.siteguard.cctv.service
+
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteOrderRequest
+import com.pluxity.siteguard.cctv.dto.CctvFavoriteRequest
+import com.pluxity.siteguard.cctv.entity.dummyCctvFavorite
+import com.pluxity.siteguard.cctv.repository.CctvFavoriteRepository
+import com.pluxity.siteguard.global.constant.ErrorCode
+import com.pluxity.siteguard.global.exception.CustomException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+
+class CctvFavoriteServiceTest :
+    BehaviorSpec({
+
+        val repository: CctvFavoriteRepository = mockk(relaxed = true)
+        val service = CctvFavoriteService(repository)
+
+        Given("즐겨찾기 목록 조회") {
+
+            When("즐겨찾기가 있으면") {
+                val entities =
+                    listOf(
+                        dummyCctvFavorite(id = 1L, streamName = "cam1", displayOrder = 1),
+                        dummyCctvFavorite(id = 2L, streamName = "cam2", displayOrder = 2),
+                    )
+
+                every { repository.findAllByOrderByDisplayOrderAsc() } returns entities
+
+                val result = service.findAll()
+
+                Then("순서대로 반환된다") {
+                    result.size shouldBe 2
+                    result[0].displayOrder shouldBe 1
+                    result[1].displayOrder shouldBe 2
+                }
+            }
+
+            When("즐겨찾기가 없으면") {
+                every { repository.findAllByOrderByDisplayOrderAsc() } returns emptyList()
+
+                val result = service.findAll()
+
+                Then("빈 목록이 반환된다") {
+                    result.size shouldBe 0
+                }
+            }
+        }
+
+        Given("즐겨찾기 등록") {
+
+            When("정상적으로 등록하면") {
+                val request = CctvFavoriteRequest(streamName = "cam1")
+                val saved = dummyCctvFavorite(id = 1L, streamName = "cam1", displayOrder = 1)
+
+                every { repository.existsByStreamName("cam1") } returns false
+                every { repository.count() } returns 0
+                every { repository.save(any()) } returns saved
+
+                val result = service.create(request)
+
+                Then("ID가 반환된다") {
+                    result shouldBe 1L
+                }
+            }
+
+            When("이미 즐겨찾기된 경로를 등록하면") {
+                val request = CctvFavoriteRequest(streamName = "cam1")
+
+                every { repository.existsByStreamName("cam1") } returns true
+
+                Then("ALREADY_FAVORITE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.create(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.ALREADY_FAVORITE
+                }
+            }
+
+            When("즐겨찾기가 4개인 상태에서 등록하면") {
+                val request = CctvFavoriteRequest(streamName = "cam5")
+
+                every { repository.existsByStreamName("cam5") } returns false
+                every { repository.count() } returns 4
+
+                Then("EXCEED_FAVORITE_LIMIT 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.create(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.EXCEED_FAVORITE_LIMIT
+                }
+            }
+        }
+
+        Given("즐겨찾기 삭제") {
+
+            When("존재하는 즐겨찾기를 삭제하면") {
+                val entity = dummyCctvFavorite(id = 1L, streamName = "cam1")
+
+                every { repository.findByIdOrNull(1L) } returns entity
+
+                service.delete(1L)
+
+                Then("삭제가 수행된다") {
+                    verify { repository.delete(entity) }
+                }
+            }
+
+            When("존재하지 않는 즐겨찾기를 삭제하면") {
+                every { repository.findByIdOrNull(999L) } returns null
+
+                Then("NOT_FOUND_CCTV_FAVORITE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.delete(999L)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV_FAVORITE
+                }
+            }
+        }
+
+        Given("즐겨찾기 순서 변경") {
+
+            When("순서를 변경하면") {
+                val fav1 = dummyCctvFavorite(id = 1L, streamName = "cam1", displayOrder = 1)
+                val fav2 = dummyCctvFavorite(id = 2L, streamName = "cam2", displayOrder = 2)
+                val request = CctvFavoriteOrderRequest(ids = listOf(2L, 1L))
+
+                every { repository.findAllById(listOf(2L, 1L)) } returns listOf(fav1, fav2)
+
+                service.updateOrder(request)
+
+                Then("순서가 변경된다") {
+                    fav2.displayOrder shouldBe 1
+                    fav1.displayOrder shouldBe 2
+                }
+            }
+
+            When("존재하지 않는 ID가 포함되면") {
+                val fav1 = dummyCctvFavorite(id = 1L, streamName = "cam1", displayOrder = 1)
+                val request = CctvFavoriteOrderRequest(ids = listOf(1L, 999L))
+
+                every { repository.findAllById(listOf(1L, 999L)) } returns listOf(fav1)
+
+                Then("NOT_FOUND_CCTV_FAVORITE 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.updateOrder(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV_FAVORITE
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvFavoriteServiceTest.kt
@@ -132,6 +132,7 @@ class CctvFavoriteServiceTest :
                 val fav2 = dummyCctvFavorite(id = 2L, streamName = "cam2", displayOrder = 2)
                 val request = CctvFavoriteOrderRequest(ids = listOf(2L, 1L))
 
+                every { repository.count() } returns 2
                 every { repository.findAllById(listOf(2L, 1L)) } returns listOf(fav1, fav2)
 
                 service.updateOrder(request)
@@ -142,10 +143,25 @@ class CctvFavoriteServiceTest :
                 }
             }
 
+            When("일부 ID만 포함되면") {
+                val request = CctvFavoriteOrderRequest(ids = listOf(1L))
+
+                every { repository.count() } returns 3
+
+                Then("INVALID_FAVORITE_ORDER_COUNT 예외가 발생한다") {
+                    val exception =
+                        shouldThrow<CustomException> {
+                            service.updateOrder(request)
+                        }
+                    exception.errorCode shouldBe ErrorCode.INVALID_FAVORITE_ORDER_COUNT
+                }
+            }
+
             When("존재하지 않는 ID가 포함되면") {
                 val fav1 = dummyCctvFavorite(id = 1L, streamName = "cam1", displayOrder = 1)
                 val request = CctvFavoriteOrderRequest(ids = listOf(1L, 999L))
 
+                every { repository.count() } returns 2
                 every { repository.findAllById(listOf(1L, 999L)) } returns listOf(fav1)
 
                 Then("NOT_FOUND_CCTV_FAVORITE 예외가 발생한다") {

--- a/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvServiceTest.kt
+++ b/src/test/kotlin/com/pluxity/siteguard/cctv/service/CctvServiceTest.kt
@@ -5,6 +5,8 @@ import com.pluxity.siteguard.cctv.dto.CctvUpdateRequest
 import com.pluxity.siteguard.cctv.dto.MediaServerPathItem
 import com.pluxity.siteguard.cctv.entity.Cctv
 import com.pluxity.siteguard.cctv.entity.dummyCctv
+import com.pluxity.siteguard.cctv.entity.dummyCctvFavorite
+import com.pluxity.siteguard.cctv.repository.CctvFavoriteRepository
 import com.pluxity.siteguard.cctv.repository.CctvRepository
 import com.pluxity.siteguard.global.constant.ErrorCode
 import com.pluxity.siteguard.global.exception.CustomException
@@ -20,12 +22,13 @@ class CctvServiceTest :
     BehaviorSpec({
 
         val repository: CctvRepository = mockk(relaxed = true)
+        val favoriteRepository: CctvFavoriteRepository = mockk(relaxed = true)
         val apiClient: CctvApiClient = mockk()
-        val service = CctvService(repository, apiClient)
+        val service = CctvService(repository, favoriteRepository, apiClient)
 
         Given("CCTV 동기화") {
 
-            When("미디어서버에 새로운 path가 있으면") {
+            When("미디어서버에 새로운 streamName이 있으면") {
                 val externalPaths =
                     listOf(
                         MediaServerPathItem(name = "cam1", confName = "conf1", ready = true),
@@ -42,8 +45,8 @@ class CctvServiceTest :
                 }
             }
 
-            When("DB에 있지만 미디어서버에 없는 path가 있으면") {
-                val existingCctv = dummyCctv(id = 1L, path = "cam_old")
+            When("DB에 있지만 미디어서버에 없는 streamName이 있으면") {
+                val existingCctv = dummyCctv(id = 1L, streamName = "cam_old")
 
                 every { apiClient.fetchPaths() } returns
                     listOf(
@@ -54,12 +57,12 @@ class CctvServiceTest :
                 service.sync()
 
                 Then("해당 CCTV가 삭제된다") {
-                    verify { repository.deleteAllInBatch(match<List<Cctv>> { it.size == 1 && it[0].path == "cam_old" }) }
+                    verify { repository.deleteAllInBatch(match<List<Cctv>> { it.size == 1 && it[0].streamName == "cam_old" }) }
                 }
             }
 
             When("미디어서버와 DB가 동일하면") {
-                val existingCctv = dummyCctv(id = 1L, path = "cam1")
+                val existingCctv = dummyCctv(id = 1L, streamName = "cam1")
 
                 every { apiClient.fetchPaths() } returns
                     listOf(
@@ -78,26 +81,54 @@ class CctvServiceTest :
 
         Given("CCTV 목록 조회") {
 
-            When("CCTV 목록을 조회하면") {
+            When("즐겨찾기가 있으면 즐겨찾기 순서대로 먼저 나온다") {
                 val entities =
                     listOf(
-                        dummyCctv(id = 1L, path = "cam1", name = "1번 카메라", isFavorite = true),
-                        dummyCctv(id = 2L, path = "cam2", name = "2번 카메라"),
+                        dummyCctv(id = 1L, streamName = "cam1", name = "A 카메라"),
+                        dummyCctv(id = 2L, streamName = "cam2", name = "B 카메라"),
+                        dummyCctv(id = 3L, streamName = "cam3", name = "C 카메라"),
+                    )
+                val favorites =
+                    listOf(
+                        dummyCctvFavorite(id = 1L, streamName = "cam3", displayOrder = 1),
+                        dummyCctvFavorite(id = 2L, streamName = "cam1", displayOrder = 2),
                     )
 
-                every { repository.findAllByOrderByIsFavoriteDescNameAsc() } returns entities
+                every { repository.findAll() } returns entities
+                every { favoriteRepository.findAllByOrderByDisplayOrderAsc() } returns favorites
 
                 val result = service.findAll()
 
-                Then("목록이 반환된다") {
+                Then("즐겨찾기(displayOrder순) → 나머지(name순)으로 정렬된다") {
+                    result.size shouldBe 3
+                    result[0].streamName shouldBe "cam3"
+                    result[1].streamName shouldBe "cam1"
+                    result[2].streamName shouldBe "cam2"
+                }
+            }
+
+            When("즐겨찾기가 없으면 이름순으로 반환된다") {
+                val entities =
+                    listOf(
+                        dummyCctv(id = 1L, streamName = "cam2", name = "B 카메라"),
+                        dummyCctv(id = 2L, streamName = "cam1", name = "A 카메라"),
+                    )
+
+                every { repository.findAll() } returns entities
+                every { favoriteRepository.findAllByOrderByDisplayOrderAsc() } returns emptyList()
+
+                val result = service.findAll()
+
+                Then("이름순으로 반환된다") {
                     result.size shouldBe 2
-                    result[0].isFavorite shouldBe true
-                    result[1].isFavorite shouldBe false
+                    result[0].name shouldBe "A 카메라"
+                    result[1].name shouldBe "B 카메라"
                 }
             }
 
             When("CCTV가 없으면") {
-                every { repository.findAllByOrderByIsFavoriteDescNameAsc() } returns emptyList()
+                every { repository.findAll() } returns emptyList()
+                every { favoriteRepository.findAllByOrderByDisplayOrderAsc() } returns emptyList()
 
                 val result = service.findAll()
 
@@ -110,7 +141,7 @@ class CctvServiceTest :
         Given("CCTV 수정") {
 
             When("존재하는 CCTV를 수정하면") {
-                val entity = dummyCctv(id = 1L, path = "cam1")
+                val entity = dummyCctv(id = 1L, streamName = "cam1")
                 val request = CctvUpdateRequest(name = "1번 카메라", lon = 127.0, lat = 37.0)
 
                 every { repository.findByIdOrNull(1L) } returns entity
@@ -131,92 +162,6 @@ class CctvServiceTest :
                     val exception =
                         shouldThrow<CustomException> {
                             service.update(999L, CctvUpdateRequest(name = "test", lon = null, lat = null))
-                        }
-                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV
-                }
-            }
-        }
-
-        Given("즐겨찾기 추가") {
-
-            When("즐겨찾기가 아닌 CCTV에 추가하면") {
-                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = false)
-
-                every { repository.findByIdOrNull(1L) } returns entity
-                every { repository.countByIsFavoriteTrue() } returns 2
-
-                service.addFavorite(1L)
-
-                Then("즐겨찾기가 설정된다") {
-                    entity.isFavorite shouldBe true
-                }
-            }
-
-            When("이미 즐겨찾기인 CCTV에 추가하면") {
-                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = true)
-
-                every { repository.findByIdOrNull(1L) } returns entity
-
-                Then("ALREADY_FAVORITE 예외가 발생한다") {
-                    val exception =
-                        shouldThrow<CustomException> {
-                            service.addFavorite(1L)
-                        }
-                    exception.errorCode shouldBe ErrorCode.ALREADY_FAVORITE
-                }
-            }
-
-            When("즐겨찾기가 4개인 상태에서 추가하면") {
-                val entity = dummyCctv(id = 5L, path = "cam5", isFavorite = false)
-
-                every { repository.findByIdOrNull(5L) } returns entity
-                every { repository.countByIsFavoriteTrue() } returns 4
-
-                Then("EXCEED_FAVORITE_LIMIT 예외가 발생한다") {
-                    val exception =
-                        shouldThrow<CustomException> {
-                            service.addFavorite(5L)
-                        }
-                    exception.errorCode shouldBe ErrorCode.EXCEED_FAVORITE_LIMIT
-                }
-            }
-        }
-
-        Given("즐겨찾기 해제") {
-
-            When("즐겨찾기인 CCTV를 해제하면") {
-                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = true)
-
-                every { repository.findByIdOrNull(1L) } returns entity
-
-                service.removeFavorite(1L)
-
-                Then("즐겨찾기가 해제된다") {
-                    entity.isFavorite shouldBe false
-                }
-            }
-
-            When("즐겨찾기가 아닌 CCTV를 해제하면") {
-                val entity = dummyCctv(id = 1L, path = "cam1", isFavorite = false)
-
-                every { repository.findByIdOrNull(1L) } returns entity
-
-                Then("NOT_FAVORITE 예외가 발생한다") {
-                    val exception =
-                        shouldThrow<CustomException> {
-                            service.removeFavorite(1L)
-                        }
-                    exception.errorCode shouldBe ErrorCode.NOT_FAVORITE
-                }
-            }
-
-            When("존재하지 않는 CCTV를 해제하면") {
-                every { repository.findByIdOrNull(999L) } returns null
-
-                Then("NOT_FOUND_CCTV 예외가 발생한다") {
-                    val exception =
-                        shouldThrow<CustomException> {
-                            service.removeFavorite(999L)
                         }
                     exception.errorCode shouldBe ErrorCode.NOT_FOUND_CCTV
                 }


### PR DESCRIPTION
## 요약
CCTV 즐겨찾기를 별도 엔티티로 분리하고, path를 streamName으로 변경

## 이슈 넘버 or 관련 링크

## 변경사항 🏗️

### 즐겨찾기 엔티티 분리         
- `Cctv` 엔티티의 `isFavorite` 필드 제거, 별도 `CctvFavorite` 엔티티 신규 생성
- 즐겨찾기 전용 CRUD API 추가 (`/cctv-favorites`)
  - `GET` 목록 조회 (displayOrder순)         
  - `POST` 등록 (최대 4개, streamName 유니크)
  - `DELETE /{id}` 삭제
  - `PATCH /order` 순서 변경

### 필드 리네이밍
- CCTV/즐겨찾기 엔티티의 `path` → `streamName`으로 변경

### 목록 조회 정렬 개선
- CCTV 목록 조회 시 즐겨찾기(displayOrder순) 우선, 나머지 이름순 정렬

### ErrorCode 정리
- `NOT_FAVORITE` 제거, `NOT_FOUND_CCTV_FAVORITE` 추가
- `ALREADY_FAVORITE` 메시지 "경로가" → "스트림명이" 수정

### Checklist 📋
- [x] 즐겨찾기 등록 최대 4개 제한 및 streamName 중복 검증
- [x] 즐겨찾기 삭제 시 존재하지 않는 ID 예외 처리
- [x] 즐겨찾기 순서 변경 displayOrder 반영
- [x] CCTV 목록 조회 즐겨찾기 우선 정렬
- [x] CctvFavoriteServiceTest 단위테스트 추가
- [x] CctvServiceTest 즐겨찾기 우선 정렬 테스트 반영
## 코드 변경 사항
| 파일 | 변경 내용 |
|------|-----------|
| `CctvFavorite.kt` | 즐겨찾기 엔티티 신규 생성 (streamName, displayOrder) |
| `CctvFavoriteRepository.kt` | 즐겨찾기 Repository 추가 |
| `CctvFavoriteService.kt` | 즐겨찾기 CRUD 및 순서 변경 서비스 추가 |
| `CctvFavoriteController.kt` | 즐겨찾기 API 컨트롤러 추가 |
| `CctvFavoriteRequest.kt` | 즐겨찾기 등록/순서변경 요청 DTO 추가 |
| `CctvFavoriteResponse.kt` | 즐겨찾기 응답 DTO 추가 |
| `Cctv.kt` | `path` → `streamName`, `isFavorite` 제거 |
| `CctvResponse.kt` | `path` → `streamName`, `isFavorite` 제거 |
| `CctvRepository.kt` | 미사용 메서드 제거 |
| `CctvService.kt` | 즐겨찾기 우선 정렬 로직 적용, 기존 즐겨찾기 메서드 제거 |
| `CctvController.kt` | 기존 즐겨찾기 API 제거 |
| `ErrorCode.kt` | `NOT_FAVORITE` → `NOT_FOUND_CCTV_FAVORITE`, 메시지 수정 |
| `CctvFavoriteServiceTest.kt` | 즐겨찾기 서비스 단위테스트 추가 |
| `CctvServiceTest.kt` | 즐겨찾기 우선 정렬 테스트 반영 |

- [ ] PR 설명에 변경 사항을 명확히 기재했습니다.
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
